### PR TITLE
[Feat/#96] 공용 Avatar컴포넌트 구현

### DIFF
--- a/src/components/common/avatar/Avatar.tsx
+++ b/src/components/common/avatar/Avatar.tsx
@@ -1,7 +1,0 @@
-/**
- * 프로필 이미지를 표시하는 공용 아바타 컴포넌트입니다.
- */
-
-export default function Avatar() {
-  return <div>Avatar</div>;
-}

--- a/src/components/common/avatar/AvatarStack.tsx
+++ b/src/components/common/avatar/AvatarStack.tsx
@@ -1,7 +1,0 @@
-/**
- * 여러 유저의 프로필 이미지를 겹쳐서 표시하는 공용 컴포넌트입니다.
- */
-
-export default function AvatarStack() {
-  return <div>AvatarStack</div>;
-}

--- a/src/components/common/avatar/UserProfile.tsx
+++ b/src/components/common/avatar/UserProfile.tsx
@@ -1,7 +1,0 @@
-/**
- * 유저 프로필 정보를 표시하는 공용 컴포넌트입니다.
- */
-
-export default function UserProfile() {
-  return <div>UserProfile</div>;
-}

--- a/src/components/common/avatar/components/Avatar.tsx
+++ b/src/components/common/avatar/components/Avatar.tsx
@@ -1,6 +1,5 @@
 /**
  * 프로필 이미지를 표시하는 기본 아바타 컴포넌트입니다.
- * 기본 프레임은 사이드바 푸터(40×40, 내부 24×24, rounded-lg)와 동일합니다.
  * 이미지가 없으면 기본 유저 아이콘을 표시합니다.
  */
 
@@ -26,59 +25,23 @@ export default function Avatar({
 }: AvatarProps) {
   const isSidebarFrame = size === 40;
 
-  if (isSidebarFrame) {
-    return (
-      <span
-        className={cn(
-          'flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-background-tertiary',
-          className,
-        )}
-      >
-        {src ? (
-          <Image
-            src={src}
-            alt={alt}
-            width={24}
-            height={24}
-            className="size-6 object-cover"
-          />
-        ) : (
-          <Image
-            src={icUserLarge}
-            alt={alt}
-            width={24}
-            height={24}
-            className="size-6 object-cover"
-          />
-        )}
-      </span>
-    );
-  }
-
   return (
     <span
       className={cn(
-        'flex size-6 shrink-0 overflow-hidden rounded-lg bg-background-secondary',
+        'flex shrink-0 overflow-hidden rounded-lg',
+        isSidebarFrame
+          ? 'size-10 items-center justify-center bg-background-tertiary'
+          : 'size-6 bg-background-secondary',
         className,
       )}
     >
-      {src ? (
-        <Image
-          src={src}
-          alt={alt}
-          width={24}
-          height={24}
-          className="size-6 object-cover"
-        />
-      ) : (
-        <Image
-          src={icUserLarge}
-          alt={alt}
-          width={24}
-          height={24}
-          className="size-6 object-cover"
-        />
-      )}
+      <Image
+        src={src || icUserLarge}
+        alt={alt}
+        width={24}
+        height={24}
+        className="size-6 object-cover"
+      />
     </span>
   );
 }

--- a/src/components/common/avatar/components/Avatar.tsx
+++ b/src/components/common/avatar/components/Avatar.tsx
@@ -1,25 +1,20 @@
 /**
  * 프로필 이미지를 표시하는 기본 아바타 컴포넌트입니다.
  * 이미지가 없으면 기본 유저 아이콘을 표시합니다.
+ * `alt`는 가능하면 호출부에서 사용자 이름 등을 넘기고, 생략 시 짧은 기본 문구로 대체합니다.
  */
 
 import Image from 'next/image';
 
 import { icUserLarge } from '@/assets';
-import type { AvatarFrameSize } from '@/components/common/avatar/types';
+import type { AvatarProps } from '@/components/common/avatar/types';
 import { cn } from '@/utils/cn';
 
-type AvatarProps = {
-  src?: string;
-  alt?: string;
-  /** 기본 40(사이드바와 동일). 24는 한 칸 전체를 이미지가 채우는 컴팩트 크기 */
-  size?: AvatarFrameSize;
-  className?: string;
-};
+const DEFAULT_AVATAR_ALT = '프로필 이미지';
 
 export default function Avatar({
   src,
-  alt = '',
+  alt,
   size = 40,
   className,
 }: AvatarProps) {
@@ -37,7 +32,7 @@ export default function Avatar({
     >
       <Image
         src={src || icUserLarge}
-        alt={alt}
+        alt={alt ?? DEFAULT_AVATAR_ALT}
         width={24}
         height={24}
         className="size-6 object-cover"

--- a/src/components/common/avatar/components/Avatar.tsx
+++ b/src/components/common/avatar/components/Avatar.tsx
@@ -1,0 +1,84 @@
+/**
+ * 프로필 이미지를 표시하는 기본 아바타 컴포넌트입니다.
+ * 기본 프레임은 사이드바 푸터(40×40, 내부 24×24, rounded-lg)와 동일합니다.
+ * 이미지가 없으면 기본 유저 아이콘을 표시합니다.
+ */
+
+import Image from 'next/image';
+
+import { icUserLarge } from '@/assets';
+import type { AvatarFrameSize } from '@/components/common/avatar/types';
+import { cn } from '@/utils/cn';
+
+type AvatarProps = {
+  src?: string;
+  alt?: string;
+  /** 기본 40(사이드바와 동일). 24는 한 칸 전체를 이미지가 채우는 컴팩트 크기 */
+  size?: AvatarFrameSize;
+  className?: string;
+};
+
+export default function Avatar({
+  src,
+  alt = '',
+  size = 40,
+  className,
+}: AvatarProps) {
+  const isSidebarFrame = size === 40;
+
+  if (isSidebarFrame) {
+    return (
+      <span
+        className={cn(
+          'flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-background-tertiary',
+          className,
+        )}
+      >
+        {src ? (
+          <Image
+            src={src}
+            alt={alt}
+            width={24}
+            height={24}
+            className="size-6 object-cover"
+          />
+        ) : (
+          <Image
+            src={icUserLarge}
+            alt={alt}
+            width={24}
+            height={24}
+            className="size-6 object-cover"
+          />
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'flex size-6 shrink-0 overflow-hidden rounded-lg bg-background-secondary',
+        className,
+      )}
+    >
+      {src ? (
+        <Image
+          src={src}
+          alt={alt}
+          width={24}
+          height={24}
+          className="size-6 object-cover"
+        />
+      ) : (
+        <Image
+          src={icUserLarge}
+          alt={alt}
+          width={24}
+          height={24}
+          className="size-6 object-cover"
+        />
+      )}
+    </span>
+  );
+}

--- a/src/components/common/avatar/components/AvatarStack.tsx
+++ b/src/components/common/avatar/components/AvatarStack.tsx
@@ -5,19 +5,14 @@
 
 import Image from 'next/image';
 
-import type { AvatarMember } from '@/components/common/avatar/types';
+import type { AvatarStackProps } from '@/components/common/avatar/types';
 import { cn } from '@/utils/cn';
-
-type AvatarStackProps = {
-  members: AvatarMember[];
-  className?: string;
-};
 
 export default function AvatarStack({ members, className }: AvatarStackProps) {
   return (
     <div
       className={cn(
-        'flex h-7 w-[75px] flex-row items-center gap-1.5 rounded-lg border border-background-tertiary bg-background-primary py-1 pr-2 pl-1 md:h-8 md:w-[87px]',
+        'flex h-7 w-18.75 flex-row items-center gap-1.5 rounded-lg border border-background-tertiary bg-background-primary py-1 pr-2 pl-1 md:h-8 md:w-21.75',
         className,
       )}
     >

--- a/src/components/common/avatar/components/AvatarStack.tsx
+++ b/src/components/common/avatar/components/AvatarStack.tsx
@@ -1,0 +1,42 @@
+/**
+ * 여러 유저의 프로필 이미지를 겹쳐서 표시하는 아바타 스택 컴포넌트입니다.
+ * 배열 앞쪽(왼쪽) 이미지가 겹침 영역에서 위에 보이도록 쌓습니다.
+ */
+
+import Image from 'next/image';
+
+import type { AvatarMember } from '@/components/common/avatar/types';
+import { cn } from '@/utils/cn';
+
+type AvatarStackProps = {
+  members: AvatarMember[];
+  className?: string;
+};
+
+export default function AvatarStack({ members, className }: AvatarStackProps) {
+  return (
+    <div
+      className={cn(
+        'flex h-7 w-[75px] flex-row items-center gap-1.5 rounded-lg border border-background-tertiary bg-background-primary py-1 pr-2 pl-1 md:h-8 md:w-[87px]',
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-row items-center">
+        {members.map((member, index) => (
+          <Image
+            key={member.userId}
+            src={member.userImage}
+            alt={member.userName}
+            width={24}
+            height={24}
+            className="relative -ml-1.5 size-5 shrink-0 rounded-lg border border-background-inverse object-cover first:ml-0 md:-ml-2 md:size-6"
+            style={{ zIndex: members.length - index }}
+          />
+        ))}
+      </div>
+      <p className="shrink-0 text-xs font-medium text-text-default md:text-[13px]">
+        {members.length}
+      </p>
+    </div>
+  );
+}

--- a/src/components/common/avatar/components/UserProfile.tsx
+++ b/src/components/common/avatar/components/UserProfile.tsx
@@ -3,14 +3,8 @@
  */
 
 import Avatar from '@/components/common/avatar/components/Avatar';
+import type { UserProfileProps } from '@/components/common/avatar/types';
 import { cn } from '@/utils/cn';
-
-type UserProfileProps = {
-  src?: string;
-  name: string;
-  description?: string;
-  className?: string;
-};
 
 export default function UserProfile({
   src,

--- a/src/components/common/avatar/components/UserProfile.tsx
+++ b/src/components/common/avatar/components/UserProfile.tsx
@@ -1,0 +1,36 @@
+/**
+ * 아바타 이미지와 이름, 설명을 함께 표시하는 유저 프로필 컴포넌트입니다.
+ */
+
+import Avatar from '@/components/common/avatar/components/Avatar';
+import { cn } from '@/utils/cn';
+
+type UserProfileProps = {
+  src?: string;
+  name: string;
+  description?: string;
+  className?: string;
+};
+
+export default function UserProfile({
+  src,
+  name,
+  description,
+  className,
+}: UserProfileProps) {
+  return (
+    <div className={cn('flex min-w-0 items-center gap-3', className)}>
+      <Avatar src={src} alt={name} />
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-base font-semibold text-text-primary">
+          {name}
+        </span>
+        {description && (
+          <span className="truncate text-sm font-medium text-text-default">
+            {description}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/avatar/index.ts
+++ b/src/components/common/avatar/index.ts
@@ -1,3 +1,10 @@
 export { default as Avatar } from '@/components/common/avatar/components/Avatar';
 export { default as UserProfile } from '@/components/common/avatar/components/UserProfile';
 export { default as AvatarStack } from '@/components/common/avatar/components/AvatarStack';
+export type {
+  AvatarFrameSize,
+  AvatarMember,
+  AvatarProps,
+  AvatarStackProps,
+  UserProfileProps,
+} from '@/components/common/avatar/types';

--- a/src/components/common/avatar/index.ts
+++ b/src/components/common/avatar/index.ts
@@ -1,0 +1,3 @@
+export { default as Avatar } from '@/components/common/avatar/components/Avatar';
+export { default as UserProfile } from '@/components/common/avatar/components/UserProfile';
+export { default as AvatarStack } from '@/components/common/avatar/components/AvatarStack';

--- a/src/components/common/avatar/types.ts
+++ b/src/components/common/avatar/types.ts
@@ -8,3 +8,24 @@ export type AvatarMember = {
   userName: string;
   userImage: string;
 };
+
+export type AvatarProps = {
+  src?: string;
+  /** 생략 시 스크린리더용 기본 문구 사용. 가능하면 사용자 이름 등을 넘기는 것을 권장합니다. */
+  alt?: string;
+  /** 기본 40(사이드바와 동일). 24는 한 칸 전체를 이미지가 채우는 컴팩트 크기 */
+  size?: AvatarFrameSize;
+  className?: string;
+};
+
+export type AvatarStackProps = {
+  members: AvatarMember[];
+  className?: string;
+};
+
+export type UserProfileProps = {
+  src?: string;
+  name: string;
+  description?: string;
+  className?: string;
+};

--- a/src/components/common/avatar/types.ts
+++ b/src/components/common/avatar/types.ts
@@ -1,0 +1,10 @@
+/** 아바타 컴포넌트에서 사용하는 타입 정의입니다. */
+
+/** 40: 사이드바 푸터와 동일(40px 프레임, 24px 이미지). 24: 한 칸 전체에 이미지 */
+export type AvatarFrameSize = 40 | 24;
+
+export type AvatarMember = {
+  userId: number;
+  userName: string;
+  userImage: string;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #96


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="279" height="233" alt="스크린샷 2026-04-25 오전 8 18 04" src="https://github.com/user-attachments/assets/9e581d29-caf5-4c45-abd8-7d58747de6c6" />


Avatar | src가 있으면 프로필 이미지, 없으면 기본 유저 아이콘. 기본 size={40}은 사이드바 푸터와 동일한 40×40 프레임 + 내부 24×24, rounded-lg. size={24}는 24×24 한 칸(컴팩트).
-- | --
UserProfile | 위 Avatar(기본 40) + 이름 + description. 
AvatarStack | members 배열로 겹침 표시 + 전체 인원 수 텍스트. 배열 앞쪽(왼쪽)이 겹침 위에 오도록 z-index 처리. 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
