### PR TITLE
[Refactor/#148] 내히스토리, 로그인, 회원가입, 댓글 달기 후 리다이렉트 등 리펙토링

### DIFF
--- a/src/app/(service)/boards/[articleId]/components/BoardDetailCommentComposer.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailCommentComposer.tsx
@@ -56,14 +56,14 @@ export default function BoardDetailCommentComposer({
           }
           className="w-full border-y border-background-tertiary p-3 text-sm font-normal 
           text-text-primary outline-none placeholder:text-text-default placeholder:text-sm md:text-base"
-          onClick={onRequireAuth}
-          onFocus={onRequireAuth}
+          onClick={!isAuthenticated ? onRequireAuth : undefined}
+          onFocus={!isAuthenticated ? onRequireAuth : undefined}
         />
         <button
           type="button"
           aria-label="댓글 등록"
           className="absolute right-3 bottom-3 flex h-6 w-6 items-center justify-center"
-          onClick={onRequireAuth}
+          onClick={!isAuthenticated ? onRequireAuth : undefined}
         >
           <IcArrowUpCircle
             width={24}

--- a/src/app/(service)/boards/[articleId]/components/BoardDetailCommentComposer.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailCommentComposer.tsx
@@ -1,0 +1,78 @@
+/**
+ * 게시글 상세 댓글 입력 영역을 렌더링하는 컴포넌트입니다.
+ */
+
+'use client';
+
+import Image from 'next/image';
+
+import type { UserProfileResponse } from '@/app/(service)/boards/[articleId]/types';
+import { IcArrowUpCircle, IcUserXlarge } from '@/assets';
+
+type BoardDetailCommentComposerProps = {
+  isAuthenticated: boolean;
+  onRequireAuth: () => void;
+  userProfile: UserProfileResponse | null;
+};
+
+export default function BoardDetailCommentComposer({
+  isAuthenticated,
+  onRequireAuth,
+  userProfile,
+}: BoardDetailCommentComposerProps) {
+  return (
+    <div className="flex items-center gap-3 mt-3 md:mt-4 md:gap-4">
+      <div className="overflow-hidden size-7 rounded-md bg-background-tertiary flex items-center justify-center md:size-8">
+        {userProfile?.image ? (
+          <Image
+            src={userProfile.image}
+            width={28}
+            height={28}
+            alt={`${userProfile.nickname}의 프로필 이미지`}
+            className="size-7 object-cover md:size-8"
+          />
+        ) : (
+          <IcUserXlarge
+            width={28}
+            height={28}
+            className="size-7 md:size-8"
+            role="img"
+            aria-label={
+              userProfile
+                ? `${userProfile.nickname}의 프로필 이미지`
+                : '게스트 프로필 이미지'
+            }
+          />
+        )}
+      </div>
+      <div className="relative flex-1">
+        <input
+          type="text"
+          readOnly={!isAuthenticated}
+          placeholder={
+            isAuthenticated
+              ? '댓글을 달아주세요'
+              : '댓글을 남기려면 로그인해주세요'
+          }
+          className="w-full border-y border-background-tertiary p-3 text-sm font-normal 
+          text-text-primary outline-none placeholder:text-text-default placeholder:text-sm md:text-base"
+          onClick={onRequireAuth}
+          onFocus={onRequireAuth}
+        />
+        <button
+          type="button"
+          aria-label="댓글 등록"
+          className="absolute right-3 bottom-3 flex h-6 w-6 items-center justify-center"
+          onClick={onRequireAuth}
+        >
+          <IcArrowUpCircle
+            width={24}
+            height={24}
+            role="img"
+            aria-label="댓글 등록"
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(service)/boards/[articleId]/components/BoardDetailCommentItem.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailCommentItem.tsx
@@ -1,17 +1,14 @@
 import CommentEditingContent from '@/app/(service)/boards/[articleId]/components/CommentEditingContent';
 import CommentReadonlyContent from '@/app/(service)/boards/[articleId]/components/CommentReadonlyContent';
 import { useBoardDetailCommentItem } from '@/app/(service)/boards/[articleId]/hooks/useBoardDetailCommentItem';
-import type {
-  Comment,
-  UserProfileResponse,
-} from '@/app/(service)/boards/[articleId]/types';
+import type { Comment } from '@/app/(service)/boards/[articleId]/types';
 
 export default function BoardDetailCommentItem({
   comment,
-  userProfile,
+  currentUserId,
 }: {
   comment: Comment;
-  userProfile: UserProfileResponse;
+  currentUserId?: number | null;
 }) {
   const {
     isOwnComment,
@@ -24,7 +21,7 @@ export default function BoardDetailCommentItem({
     handleEditedContentChange,
     handleDeleteConfirm,
     setIsDeleteModalOpen,
-  } = useBoardDetailCommentItem({ comment, userProfile });
+  } = useBoardDetailCommentItem({ comment, currentUserId });
 
   return (
     <>

--- a/src/app/(service)/boards/[articleId]/components/BoardDetailComments.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailComments.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Image from 'next/image';
+import { usePathname, useRouter } from 'next/navigation';
 
+import BoardDetailCommentComposer from '@/app/(service)/boards/[articleId]/components/BoardDetailCommentComposer';
 import BoardDetailCommentItem from '@/app/(service)/boards/[articleId]/components/BoardDetailCommentItem';
 import { useSortedComments } from '@/app/(service)/boards/[articleId]/hooks/useSortedComments';
 import type {
@@ -9,19 +10,30 @@ import type {
   CommentListResponse,
   UserProfileResponse,
 } from '@/app/(service)/boards/[articleId]/types';
-import { IcArrowUpCircle, IcUserXlarge } from '@/assets';
+import { buildLoginPath } from '@/utils/authRedirect';
 
 export default function BoardDetailComments({
   commentList,
   userProfile,
 }: {
   commentList: CommentListResponse;
-  userProfile: UserProfileResponse;
+  userProfile: UserProfileResponse | null;
 }) {
+  const router = useRouter();
+  const pathname = usePathname();
   const sortedComments = useSortedComments({
     comments: commentList.list,
-    userId: userProfile.id,
+    userId: userProfile?.id,
   });
+  const isAuthenticated = Boolean(userProfile);
+
+  const handleRequireAuth = () => {
+    if (isAuthenticated) {
+      return;
+    }
+
+    router.push(buildLoginPath({ redirectTo: pathname }));
+  };
 
   return (
     <div className="pb-9.75 md:pb-13.5">
@@ -34,48 +46,11 @@ export default function BoardDetailComments({
             {commentList.list.length}
           </p>
         </div>
-        <div className="flex items-center gap-3 mt-3 md:mt-4 md:gap-4">
-          <div className="overflow-hidden size-7 rounded-md bg-background-tertiary flex items-center justify-center md:size-8">
-            {userProfile.image ? (
-              <Image
-                src={userProfile.image}
-                width={28}
-                height={28}
-                alt={`${userProfile.nickname}의 프로필 이미지`}
-                className="size-7 object-cover md:size-8"
-              />
-            ) : (
-              <IcUserXlarge
-                width={28}
-                height={28}
-                className="size-7 md:size-8"
-                role="img"
-                aria-label={`${userProfile.nickname}의 프로필 이미지`}
-              />
-            )}
-          </div>
-          <div className="relative flex-1">
-            <input
-              type="text"
-              placeholder="댓글을 달아주세요"
-              className="w-full border-y border-background-tertiary p-3 text-sm font-normal 
-              text-text-primary outline-none placeholder:text-text-default placeholder:text-sm md:text-base"
-            />
-            <button
-              type="button"
-              aria-label="댓글 등록"
-              className="absolute right-3 bottom-3 flex h-6 w-6 items-center justify-center"
-              onClick={() => {}}
-            >
-              <IcArrowUpCircle
-                width={24}
-                height={24}
-                role="img"
-                aria-label="댓글 등록"
-              />
-            </button>
-          </div>
-        </div>
+        <BoardDetailCommentComposer
+          isAuthenticated={isAuthenticated}
+          onRequireAuth={handleRequireAuth}
+          userProfile={userProfile}
+        />
       </div>
       <div>
         {commentList.list.length > 0 ? (
@@ -85,7 +60,7 @@ export default function BoardDetailComments({
                 <BoardDetailCommentItem
                   key={comment.id}
                   comment={comment}
-                  userProfile={userProfile}
+                  currentUserId={userProfile?.id}
                 />
               ))}
             </ul>

--- a/src/app/(service)/boards/[articleId]/components/BoardDetailComments.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailComments.tsx
@@ -32,7 +32,12 @@ export default function BoardDetailComments({
       return;
     }
 
-    router.push(buildLoginPath({ redirectTo: pathname }));
+    router.push(
+      buildLoginPath({
+        notice: 'auth-required',
+        redirectTo: pathname,
+      }),
+    );
   };
 
   return (

--- a/src/app/(service)/boards/[articleId]/components/BoardDetailHeader.tsx
+++ b/src/app/(service)/boards/[articleId]/components/BoardDetailHeader.tsx
@@ -16,10 +16,13 @@ export default function BoardDetailHeader({
   userProfile,
 }: {
   boardDetail: BoardDetailProps['boardDetail'];
-  userProfile: UserProfileResponse;
+  userProfile: UserProfileResponse | null;
 }) {
   const { menuItems, isDeleteModalOpen, handleDeleteConfirm } =
-    useBoardDetailMenu(boardDetail.id.toString());
+    useBoardDetailMenu(
+      boardDetail.id.toString(),
+      boardDetail.writer.id === userProfile?.id,
+    );
   const { isLiked, likeCount, handleLikeClick } = useLike(boardDetail);
 
   return (
@@ -28,18 +31,20 @@ export default function BoardDetailHeader({
         <h2 className="flex-1 truncate text-text-primary font-bold text-lg leading-5.25 md:text-xl md:leading-6">
           {boardDetail.title}
         </h2>
-        <ListDropdown
-          trigger={
-            <IcMoreVerticalLarge
-              width={24}
-              height={24}
-              className="cursor-pointer"
-              role="img"
-              aria-label="더보기 메뉴"
-            />
-          }
-          items={menuItems}
-        />
+        {menuItems.length > 0 ? (
+          <ListDropdown
+            trigger={
+              <IcMoreVerticalLarge
+                width={24}
+                height={24}
+                className="cursor-pointer"
+                role="img"
+                aria-label="더보기 메뉴"
+              />
+            }
+            items={menuItems}
+          />
+        ) : null}
         {isDeleteModalOpen && (
           <Modal
             onClose={handleDeleteConfirm}
@@ -55,7 +60,7 @@ export default function BoardDetailHeader({
       <div className="flex items-center justify-between gap-2 mt-2 pb-3 border-b border-border-secondary md:mt-4">
         <div className="flex min-w-0 flex-1 items-center">
           <CommentWriterAvatar
-            image={userProfile.image}
+            image={userProfile?.image ?? null}
             nickname={boardDetail.writer.nickname}
             width={24}
             height={24}

--- a/src/app/(service)/boards/[articleId]/hooks/getBoardDetailPageData.ts
+++ b/src/app/(service)/boards/[articleId]/hooks/getBoardDetailPageData.ts
@@ -20,15 +20,17 @@ export async function getBoardDetailPageData({
   }
 
   try {
-    const [boardDetailData, userProfileData] = await Promise.all([
-      fetchWithAuth(teamEndpoint(`/articles/${articleId}`, TEAM_ID)),
-      fetchWithAuth(teamEndpoint('/user', TEAM_ID)),
-    ]);
+    const boardDetailData = await fetchWithAuth(
+      teamEndpoint(`/articles/${articleId}`, TEAM_ID),
+    );
+    const userProfileData = await fetchWithAuth(teamEndpoint('/user', TEAM_ID))
+      .then((data) => data as UserProfileResponse)
+      .catch(() => null);
 
     return {
       boardDetail: boardDetailData as Post,
       errorMessage: null,
-      userProfile: userProfileData as UserProfileResponse,
+      userProfile: userProfileData,
     } as const;
   } catch {
     return {

--- a/src/app/(service)/boards/[articleId]/hooks/getBoardDetailPageData.ts
+++ b/src/app/(service)/boards/[articleId]/hooks/getBoardDetailPageData.ts
@@ -20,12 +20,12 @@ export async function getBoardDetailPageData({
   }
 
   try {
-    const boardDetailData = await fetchWithAuth(
-      teamEndpoint(`/articles/${articleId}`, TEAM_ID),
-    );
-    const userProfileData = await fetchWithAuth(teamEndpoint('/user', TEAM_ID))
-      .then((data) => data as UserProfileResponse)
-      .catch(() => null);
+    const [boardDetailData, userProfileData] = await Promise.all([
+      fetchWithAuth(teamEndpoint(`/articles/${articleId}`, TEAM_ID)),
+      fetchWithAuth(teamEndpoint('/user', TEAM_ID))
+        .then((data) => data as UserProfileResponse)
+        .catch(() => null),
+    ]);
 
     return {
       boardDetail: boardDetailData as Post,

--- a/src/app/(service)/boards/[articleId]/hooks/useBoardDetailCommentItem.ts
+++ b/src/app/(service)/boards/[articleId]/hooks/useBoardDetailCommentItem.ts
@@ -6,27 +6,24 @@ import {
   BOARD_DETAIL_DROPDOWN_ITEMS,
   BOARD_DETAIL_MENU,
 } from '@/app/(service)/boards/[articleId]/constants';
-import type {
-  Comment,
-  UserProfileResponse,
-} from '@/app/(service)/boards/[articleId]/types';
+import type { Comment } from '@/app/(service)/boards/[articleId]/types';
 import { useToast } from '@/components/common/toast';
 
 type UseBoardDetailCommentItemParams = {
   comment: Comment;
-  userProfile: UserProfileResponse;
+  currentUserId?: number | null;
 };
 
 export const useBoardDetailCommentItem = ({
   comment,
-  userProfile,
+  currentUserId,
 }: UseBoardDetailCommentItemParams) => {
   const { showToast } = useToast();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(comment.content);
 
-  const isOwnComment = comment.writer.id === userProfile.id;
+  const isOwnComment = comment.writer.id === currentUserId;
 
   const handleEdit = () => {
     // TODO: 수정 기능 구현 로직

--- a/src/app/(service)/boards/[articleId]/hooks/useBoardDetailMenu.ts
+++ b/src/app/(service)/boards/[articleId]/hooks/useBoardDetailMenu.ts
@@ -11,7 +11,7 @@ import {
 import { useToast } from '@/components/common/toast';
 import { ROUTES } from '@/constants/ROUTES';
 
-export const useBoardDetailMenu = (articleId: string) => {
+export const useBoardDetailMenu = (articleId: string, canManage: boolean) => {
   const router = useRouter();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { showToast } = useToast();
@@ -38,5 +38,9 @@ export const useBoardDetailMenu = (articleId: string) => {
     },
   }));
 
-  return { menuItems, isDeleteModalOpen, handleDeleteConfirm };
+  return {
+    handleDeleteConfirm,
+    isDeleteModalOpen,
+    menuItems: canManage ? menuItems : [],
+  };
 };

--- a/src/app/(service)/boards/[articleId]/hooks/useSortedComments.ts
+++ b/src/app/(service)/boards/[articleId]/hooks/useSortedComments.ts
@@ -10,7 +10,7 @@ import type { Comment } from '@/app/(service)/boards/[articleId]/types';
 
 type UseSortedCommentsParams = {
   comments: Comment[];
-  userId: number;
+  userId?: number | null;
 };
 
 const parseDateToTime = (value: string) => {

--- a/src/app/(service)/boards/[articleId]/page.tsx
+++ b/src/app/(service)/boards/[articleId]/page.tsx
@@ -47,7 +47,7 @@ export default async function BoardDetailPage({
     return renderFallback(errorMessage);
   }
 
-  if (!boardDetail || !userProfile) {
+  if (!boardDetail) {
     return renderFallback('게시글 데이터를 불러오지 못했습니다.');
   }
 

--- a/src/app/(service)/boards/components/BoardWriteFloatingButton.tsx
+++ b/src/app/(service)/boards/components/BoardWriteFloatingButton.tsx
@@ -5,12 +5,22 @@ import { useRouter } from 'next/navigation';
 import { IcPencil } from '@/assets';
 import { FloatingButton } from '@/components/common/button';
 import { ROUTES } from '@/constants/ROUTES';
+import { buildLoginPath } from '@/utils/authRedirect';
+import { hasAuthSession } from '@/utils/authSession';
 
 export default function BoardWriteFloatingButton() {
   const router = useRouter();
+  const writePath = `${ROUTES.BOARDS}?write=true`;
 
   const handleClick = () => {
-    router.push(`${ROUTES.BOARDS}?write=true`, { scroll: false });
+    if (!hasAuthSession()) {
+      router.push(buildLoginPath({ redirectTo: writePath }), {
+        scroll: false,
+      });
+      return;
+    }
+
+    router.push(writePath, { scroll: false });
   };
 
   return (

--- a/src/app/(service)/boards/components/BoardWriteFloatingButton.tsx
+++ b/src/app/(service)/boards/components/BoardWriteFloatingButton.tsx
@@ -14,9 +14,15 @@ export default function BoardWriteFloatingButton() {
 
   const handleClick = () => {
     if (!hasAuthSession()) {
-      router.push(buildLoginPath({ redirectTo: writePath }), {
-        scroll: false,
-      });
+      router.push(
+        buildLoginPath({
+          notice: 'auth-required',
+          redirectTo: writePath,
+        }),
+        {
+          scroll: false,
+        },
+      );
       return;
     }
 

--- a/src/app/(service)/boards/page.tsx
+++ b/src/app/(service)/boards/page.tsx
@@ -3,6 +3,9 @@
  * API 미연동 상태에서도 정렬 로직은 동일하게 유지합니다.
  */
 
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
 import BoardBestList from '@/app/(service)/boards/components/BoardBestList';
 import BoardHeader from '@/app/(service)/boards/components/BoardHeader';
 import BoardList from '@/app/(service)/boards/components/BoardList';
@@ -18,6 +21,8 @@ import {
   hasPosts,
   isSearchMode,
 } from '@/app/(service)/boards/utils/boardUtils';
+import { ROUTES } from '@/constants/ROUTES';
+import { buildLoginPath } from '@/utils/authRedirect';
 
 export default async function BoardsPage({
   searchParams,
@@ -28,6 +33,16 @@ export default async function BoardsPage({
   const keyword = parsedParams.search;
   const isSearchModeValue = isSearchMode(keyword);
   const isWriteMode = parsedParams.write === 'true';
+
+  if (isWriteMode) {
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('access-token')?.value;
+
+    if (!accessToken) {
+      redirect(buildLoginPath({ redirectTo: `${ROUTES.BOARDS}?write=true` }));
+    }
+  }
+
   const fetchedPosts: Post[] = [];
   const bestPosts = getBoardBestPosts(fetchedPosts);
   const listPosts = sortBoardMainListPostsByRecent(fetchedPosts);

--- a/src/app/(service)/boards/page.tsx
+++ b/src/app/(service)/boards/page.tsx
@@ -39,7 +39,12 @@ export default async function BoardsPage({
     const accessToken = cookieStore.get('access-token')?.value;
 
     if (!accessToken) {
-      redirect(buildLoginPath({ redirectTo: `${ROUTES.BOARDS}?write=true` }));
+      redirect(
+        buildLoginPath({
+          notice: 'auth-required',
+          redirectTo: `${ROUTES.BOARDS}?write=true`,
+        }),
+      );
     }
   }
 

--- a/src/app/(service)/login/components/LoginForm.tsx
+++ b/src/app/(service)/login/components/LoginForm.tsx
@@ -5,15 +5,25 @@ import { useState } from 'react';
 import Link from 'next/link';
 
 import ForgotPasswordModal from '@/app/(service)/login/components/ForgotPasswordModal';
-import { LOGIN_LINKS, LOGIN_TEXT } from '@/app/(service)/login/constants';
+import { LOGIN_TEXT } from '@/app/(service)/login/constants';
 import useLoginForm from '@/app/(service)/login/hooks/useLoginForm';
-import { IcKakaotalk } from '@/assets';
 import { PrimaryButton } from '@/components/common/button';
-import { AuthInput } from '@/components/common/form';
-import FullLogo from '@/components/common/logo/FullLogo';
-import { ROUTES } from '@/constants/ROUTES';
+import {
+  AuthInput,
+  AuthSocialSection,
+  AuthTitleBlock,
+} from '@/components/common/form';
+import { buildSignupPath } from '@/utils/authRedirect';
 
-export default function LoginForm() {
+type LoginFormProps = {
+  prefilledEmail?: string;
+  redirectTo?: string;
+};
+
+export default function LoginForm({
+  prefilledEmail,
+  redirectTo,
+}: LoginFormProps) {
   const [isForgotPasswordModalOpen, setIsForgotPasswordModalOpen] =
     useState(false);
 
@@ -25,26 +35,15 @@ export default function LoginForm() {
     passwordError,
     passwordField,
     serverError,
-  } = useLoginForm();
+  } = useLoginForm({
+    prefilledEmail,
+    redirectTo,
+  });
 
   return (
     <section className="mx-auto w-full max-w-lg rounded-[20px] bg-background-inverse px-5.25 py-9.25 md:px-8 md:py-12.5">
-      {/* 로고 */}
-      <h1 className="mb-8 flex justify-center md:mb-10">
-        <Link href={ROUTES.HOME} aria-label="Coworkers 홈으로 이동">
-          <FullLogo
-            size="auth"
-            className="origin-center scale-90 md:scale-100"
-          />
-        </Link>
-      </h1>
+      <AuthTitleBlock title={LOGIN_TEXT.title} />
 
-      {/* 타이틀 */}
-      <h2 className="mb-6 text-center text-base font-semibold text-text-primary md:mb-8 md:text-lg">
-        {LOGIN_TEXT.title}
-      </h2>
-
-      {/* 폼 */}
       <form onSubmit={handleSubmit} className="flex flex-col gap-5 md:px-6">
         <AuthInput
           label={LOGIN_TEXT.emailLabel}
@@ -87,37 +86,14 @@ export default function LoginForm() {
       <p className="mt-6 text-center text-sm text-text-secondary">
         아직 계정이 없으신가요?
         <Link
-          href={LOGIN_LINKS.signup}
+          href={buildSignupPath(redirectTo)}
           className="ml-1 font-medium text-brand-primary underline"
         >
           가입하기
         </Link>
       </p>
 
-      {/* OR */}
-      <div className="mx-auto mt-10 flex w-full max-w-md items-center gap-4 md:px-6">
-        <div className="h-px flex-1 bg-background-tertiary" />
-        <span className="text-sm text-text-secondary">OR</span>
-        <div className="h-px flex-1 bg-background-tertiary" />
-      </div>
-
-      {/* 간편 로그인 */}
-      <button
-        type="button"
-        onClick={() => {
-          window.location.assign(ROUTES.OAUTH_AUTHORIZE('kakao'));
-        }}
-        className="mx-auto mt-4 flex h-11 w-full max-w-md items-center justify-between md:px-6"
-      >
-        <span className="text-sm text-text-secondary">간편 로그인하기</span>
-        <IcKakaotalk
-          width={42}
-          height={42}
-          className="h-11 w-11 cursor-pointer"
-          role="img"
-          aria-label="카카오 아이콘"
-        />
-      </button>
+      <AuthSocialSection mode="login" redirectTo={redirectTo} />
 
       {isForgotPasswordModalOpen && (
         <ForgotPasswordModal

--- a/src/app/(service)/login/components/LoginForm.tsx
+++ b/src/app/(service)/login/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Link from 'next/link';
 
@@ -13,19 +13,24 @@ import {
   AuthSocialSection,
   AuthTitleBlock,
 } from '@/components/common/form';
+import { useToast } from '@/components/common/toast';
 import { buildSignupPath } from '@/utils/authRedirect';
 
 type LoginFormProps = {
+  loginNotice?: 'auth-required';
   prefilledEmail?: string;
   redirectTo?: string;
 };
 
 export default function LoginForm({
+  loginNotice,
   prefilledEmail,
   redirectTo,
 }: LoginFormProps) {
+  const { showToast } = useToast();
   const [isForgotPasswordModalOpen, setIsForgotPasswordModalOpen] =
     useState(false);
+  const hasShownNoticeRef = useRef(false);
 
   const {
     emailError,
@@ -39,6 +44,15 @@ export default function LoginForm({
     prefilledEmail,
     redirectTo,
   });
+
+  useEffect(() => {
+    if (loginNotice !== 'auth-required' || hasShownNoticeRef.current) {
+      return;
+    }
+
+    hasShownNoticeRef.current = true;
+    showToast('로그인 후 이용해 주세요.', 'error');
+  }, [loginNotice, showToast]);
 
   return (
     <section className="mx-auto w-full max-w-lg rounded-[20px] bg-background-inverse px-5.25 py-9.25 md:px-8 md:py-12.5">

--- a/src/app/(service)/login/components/LoginPageContent.tsx
+++ b/src/app/(service)/login/components/LoginPageContent.tsx
@@ -5,17 +5,23 @@
 import LoginForm from '@/app/(service)/login/components/LoginForm';
 
 type LoginPageContentProps = {
+  loginNotice?: 'auth-required';
   prefilledEmail?: string;
   redirectTo?: string;
 };
 
 export default function LoginPageContent({
+  loginNotice,
   prefilledEmail,
   redirectTo,
 }: LoginPageContentProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background-secondary px-4 py-10">
-      <LoginForm prefilledEmail={prefilledEmail} redirectTo={redirectTo} />
+      <LoginForm
+        loginNotice={loginNotice}
+        prefilledEmail={prefilledEmail}
+        redirectTo={redirectTo}
+      />
     </div>
   );
 }

--- a/src/app/(service)/login/components/LoginPageContent.tsx
+++ b/src/app/(service)/login/components/LoginPageContent.tsx
@@ -2,14 +2,20 @@
  * 로그인 페이지의 전체 배치를 렌더링하는 컴포넌트입니다.
  */
 
-'use client';
-
 import LoginForm from '@/app/(service)/login/components/LoginForm';
 
-export default function LoginPageContent() {
+type LoginPageContentProps = {
+  prefilledEmail?: string;
+  redirectTo?: string;
+};
+
+export default function LoginPageContent({
+  prefilledEmail,
+  redirectTo,
+}: LoginPageContentProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background-secondary px-4 py-10">
-      <LoginForm />
+      <LoginForm prefilledEmail={prefilledEmail} redirectTo={redirectTo} />
     </div>
   );
 }

--- a/src/app/(service)/login/constants.ts
+++ b/src/app/(service)/login/constants.ts
@@ -12,11 +12,4 @@ export const LOGIN_TEXT = {
   loginButton: '로그인',
   signupGuide: '아직 계정이 없으신가요?',
   signupLink: '가입하기',
-  divider: 'OR',
-  kakaoLogin: '카카오로 로그인하기',
-} as const;
-
-export const LOGIN_LINKS = {
-  forgotPassword: '/find-password',
-  signup: '/signup',
 } as const;

--- a/src/app/(service)/login/hooks/useForgotPasswordForm.ts
+++ b/src/app/(service)/login/hooks/useForgotPasswordForm.ts
@@ -18,6 +18,12 @@ type UseForgotPasswordFormParams = {
   onSuccess: () => void;
 };
 
+function getForgotPasswordErrorMessage(message: string) {
+  return message.includes('이메일')
+    ? '가입하지 않은 이메일입니다. 입력한 이메일을 다시 확인해주세요.'
+    : '비밀번호 재설정 링크를 보내지 못했습니다. 잠시 후 다시 시도해주세요.';
+}
+
 export default function useForgotPasswordForm({
   onSuccess,
 }: UseForgotPasswordFormParams) {
@@ -25,7 +31,7 @@ export default function useForgotPasswordForm({
   const [serverError, setServerError] = useState('');
   const sendResetPasswordEmailMutation = useSendResetPasswordEmailMutation({
     onError: (error) => {
-      setServerError(error.message);
+      setServerError(getForgotPasswordErrorMessage(error.message));
     },
     onSuccess: () => {
       onSuccess();

--- a/src/app/(service)/login/hooks/useForgotPasswordForm.ts
+++ b/src/app/(service)/login/hooks/useForgotPasswordForm.ts
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, useWatch } from 'react-hook-form';
 
+import type { ApiError } from '@/api/types';
 import { useToast } from '@/components/common/toast';
 import { useSendResetPasswordEmailMutation } from '@/hooks/useUser';
 import {
@@ -18,10 +19,16 @@ type UseForgotPasswordFormParams = {
   onSuccess: () => void;
 };
 
-function getForgotPasswordErrorMessage(message: string) {
-  return message.includes('이메일')
-    ? '가입하지 않은 이메일입니다. 입력한 이메일을 다시 확인해주세요.'
-    : '비밀번호 재설정 링크를 보내지 못했습니다. 잠시 후 다시 시도해주세요.';
+function getForgotPasswordErrorMessage(error: ApiError) {
+  if (error.status === 404) {
+    return '가입하지 않은 이메일입니다. 입력한 이메일을 다시 확인해주세요.';
+  }
+
+  if (error.status === 400 && error.message.includes('이메일')) {
+    return '가입하지 않은 이메일입니다. 입력한 이메일을 다시 확인해주세요.';
+  }
+
+  return '비밀번호 재설정 링크를 보내지 못했습니다. 잠시 후 다시 시도해주세요.';
 }
 
 export default function useForgotPasswordForm({
@@ -31,7 +38,7 @@ export default function useForgotPasswordForm({
   const [serverError, setServerError] = useState('');
   const sendResetPasswordEmailMutation = useSendResetPasswordEmailMutation({
     onError: (error) => {
-      setServerError(getForgotPasswordErrorMessage(error.message));
+      setServerError(getForgotPasswordErrorMessage(error));
     },
     onSuccess: () => {
       onSuccess();

--- a/src/app/(service)/login/hooks/useLoginForm.ts
+++ b/src/app/(service)/login/hooks/useLoginForm.ts
@@ -8,14 +8,22 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, useWatch } from 'react-hook-form';
 
 import { ERROR_MESSAGES } from '@/constants/ERROR_MESSAGES';
-import { ROUTES } from '@/constants/ROUTES';
 import { useSignInMutation } from '@/hooks/useAuth';
 import { loginFormSchema, type LoginFormValues } from '@/types/auth';
+import { resolvePostAuthPath } from '@/utils/authRedirect';
 import { extractAuthSession, saveAuthSession } from '@/utils/authSession';
 
 const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
 
-export default function useLoginForm() {
+type UseLoginFormParams = {
+  prefilledEmail?: string;
+  redirectTo?: string;
+};
+
+export default function useLoginForm({
+  prefilledEmail,
+  redirectTo,
+}: UseLoginFormParams) {
   const router = useRouter();
   const [serverError, setServerError] = useState('');
   const signInMutation = useSignInMutation({
@@ -31,13 +39,7 @@ export default function useLoginForm() {
       }
 
       saveAuthSession(session);
-
-      if (!TEAM_ID) {
-        router.push(ROUTES.HOME);
-        return;
-      }
-
-      router.push(ROUTES.TEAM(TEAM_ID));
+      router.push(resolvePostAuthPath(TEAM_ID, redirectTo));
     },
   });
 
@@ -48,7 +50,7 @@ export default function useLoginForm() {
     register,
   } = useForm<LoginFormValues>({
     defaultValues: {
-      email: '',
+      email: prefilledEmail ?? '',
       password: '',
     },
     mode: 'onBlur',

--- a/src/app/(service)/login/page.tsx
+++ b/src/app/(service)/login/page.tsx
@@ -7,12 +7,19 @@ import LoginPageContent from '@/app/(service)/login/components/LoginPageContent'
 type LoginPageProps = {
   searchParams: Promise<{
     email?: string;
+    notice?: 'auth-required';
     redirectTo?: string;
   }>;
 };
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const { email, redirectTo } = await searchParams;
+  const { email, notice, redirectTo } = await searchParams;
 
-  return <LoginPageContent prefilledEmail={email} redirectTo={redirectTo} />;
+  return (
+    <LoginPageContent
+      loginNotice={notice}
+      prefilledEmail={email}
+      redirectTo={redirectTo}
+    />
+  );
 }

--- a/src/app/(service)/login/page.tsx
+++ b/src/app/(service)/login/page.tsx
@@ -4,6 +4,15 @@
 
 import LoginPageContent from '@/app/(service)/login/components/LoginPageContent';
 
-export default function LoginPage() {
-  return <LoginPageContent />;
+type LoginPageProps = {
+  searchParams: Promise<{
+    email?: string;
+    redirectTo?: string;
+  }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const { email, redirectTo } = await searchParams;
+
+  return <LoginPageContent prefilledEmail={email} redirectTo={redirectTo} />;
 }

--- a/src/app/(service)/myhistory/components/HistoryBoard.tsx
+++ b/src/app/(service)/myhistory/components/HistoryBoard.tsx
@@ -20,7 +20,6 @@ export default function HistoryBoard({
   isProgressivelyLoading,
   onApplyRange,
   onMoveMonth,
-  onResetRange,
   onSelectFilter,
   selectedRange,
   title,
@@ -39,7 +38,6 @@ export default function HistoryBoard({
         selectedRange={selectedRange}
         onApplyRange={onApplyRange}
         onMoveMonth={onMoveMonth}
-        onResetRange={onResetRange}
       />
 
       {filters.length > 0 ? (

--- a/src/app/(service)/myhistory/components/HistoryMonthNavigator.tsx
+++ b/src/app/(service)/myhistory/components/HistoryMonthNavigator.tsx
@@ -18,7 +18,6 @@ import {
 export default function HistoryMonthNavigator({
   onApplyRange,
   onMoveMonth,
-  onResetRange,
   selectedRange,
   title,
 }: HistoryMonthNavigatorProps) {
@@ -42,7 +41,6 @@ export default function HistoryMonthNavigator({
     isCalendarOpen,
     onApplyRange,
     onMoveMonth,
-    onResetRange,
     selectedRange,
     toggleCalendar,
   });

--- a/src/app/(service)/myhistory/components/MyHistoryPageContent.tsx
+++ b/src/app/(service)/myhistory/components/MyHistoryPageContent.tsx
@@ -57,7 +57,6 @@ export default function MyHistoryPageContent() {
             isProgressivelyLoading={isProgressivelyLoading}
             onApplyRange={handleApplyRange}
             onMoveMonth={handleMoveMonth}
-            onResetRange={handleResetRange}
             onSelectFilter={handleSelectHistoryFilter}
             selectedRange={selectedRange}
             title={title}

--- a/src/app/(service)/myhistory/constants.ts
+++ b/src/app/(service)/myhistory/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * 마이 히스토리 전역에서 공유하는 상수 모음입니다.
+ */
+
+export const MY_HISTORY_DATE_RANGE_MODES = {
+  ALL: 'all',
+  MONTH: 'month',
+  RANGE: 'range',
+} as const;

--- a/src/app/(service)/myhistory/hooks/useHistoryBoard.ts
+++ b/src/app/(service)/myhistory/hooks/useHistoryBoard.ts
@@ -1,25 +1,16 @@
 'use client';
 
 /**
- * 내 히스토리 화면의 날짜 범위, 완료 이력, 보드 상태를 조합하는 훅입니다.
+ * 내 히스토리 화면의 완료 이력 조회와 보드 표시 상태를 조합하는 훅입니다.
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import useHistoryBoardData from '@/app/(service)/myhistory/hooks/useHistoryBoardData';
-import type {
-  MyHistoryCompletedTaskRecord,
-  MyHistoryDateRange,
-  MyHistoryResolvedDateRange,
-} from '@/app/(service)/myhistory/types';
+import useHistorySelectedRange from '@/app/(service)/myhistory/hooks/useHistorySelectedRange';
+import type { MyHistoryCompletedTaskRecord } from '@/app/(service)/myhistory/types';
 import {
-  addMonths,
-  createHistoryAllRange,
-  createHistoryMonthRange,
-  formatHistoryRangeTitle,
-} from '@/app/(service)/myhistory/utils/formatHistoryDate';
-import {
-  getHistorySectionsInRange,
+  buildVisibleHistorySections,
   hasHistoryTasks,
 } from '@/app/(service)/myhistory/utils/getHistorySections';
 import {
@@ -30,8 +21,6 @@ import {
 import { useCompletedTasksQuery } from '@/hooks/useUser';
 
 export default function useHistoryBoard(activeFilterId: string | null) {
-  const [selectedRangeOverride, setSelectedRangeOverride] =
-    useState<MyHistoryDateRange | null>(null);
   const { data, isError, isLoading } = useCompletedTasksQuery();
 
   const completedTasks = useMemo<readonly MyHistoryCompletedTaskRecord[]>(
@@ -42,18 +31,22 @@ export default function useHistoryBoard(activeFilterId: string | null) {
     () => getLatestHistoryTaskDate(completedTasks) ?? new Date(),
     [completedTasks],
   );
-  const selectedRange = useMemo(() => {
-    if (selectedRangeOverride) {
-      return selectedRangeOverride;
-    }
-    return createHistoryAllRange(defaultAnchorDate);
-  }, [defaultAnchorDate, selectedRangeOverride]);
+  const {
+    handleApplyRange,
+    handleMoveMonth,
+    handleResetRange,
+    isAllRange,
+    selectedRange,
+    title,
+  } = useHistorySelectedRange({
+    defaultAnchorDate,
+  });
   const completedTasksInRange = useMemo(
     () =>
-      selectedRange.mode === 'all'
+      isAllRange
         ? completedTasks
         : getCompletedTasksInRange(completedTasks, selectedRange),
-    [completedTasks, selectedRange],
+    [completedTasks, isAllRange, selectedRange],
   );
   const {
     filters,
@@ -65,42 +58,13 @@ export default function useHistoryBoard(activeFilterId: string | null) {
   } = useHistoryBoardData({
     activeFilterId,
     completedTasks: completedTasksInRange,
-    isAllRange: selectedRange.mode === 'all',
-    shouldLimitTeamQueries:
-      activeFilterId !== null && selectedRange.mode === 'all',
+    isAllRange,
+    shouldLimitTeamQueries: activeFilterId !== null && isAllRange,
   });
   const datedHistorySections = useMemo(
-    () => getHistorySectionsInRange(historySections, selectedRange),
+    () => buildVisibleHistorySections(historySections, selectedRange),
     [historySections, selectedRange],
   );
-
-  const handleApplyRange = ({
-    endDate,
-    startDate,
-  }: MyHistoryResolvedDateRange) => {
-    setSelectedRangeOverride({
-      endDate,
-      mode: 'range',
-      startDate,
-    });
-  };
-
-  const handleMoveMonth = (monthOffset: number) => {
-    setSelectedRangeOverride((prevRange) =>
-      createHistoryMonthRange(
-        addMonths(
-          prevRange?.mode === 'all'
-            ? defaultAnchorDate
-            : (prevRange?.startDate ?? defaultAnchorDate),
-          monthOffset,
-        ),
-      ),
-    );
-  };
-
-  const handleResetRange = () => {
-    setSelectedRangeOverride(null);
-  };
 
   return {
     datedHistorySections,
@@ -114,6 +78,6 @@ export default function useHistoryBoard(activeFilterId: string | null) {
     isProgressivelyLoading,
     selectedRange,
     summaryItems,
-    title: formatHistoryRangeTitle(selectedRange),
+    title,
   } as const;
 }

--- a/src/app/(service)/myhistory/hooks/useHistoryBoardData.ts
+++ b/src/app/(service)/myhistory/hooks/useHistoryBoardData.ts
@@ -12,8 +12,8 @@ import useHistoryTeamDetails from '@/app/(service)/myhistory/hooks/useHistoryTea
 import useProgressiveHistoryDateKeys from '@/app/(service)/myhistory/hooks/useProgressiveHistoryDateKeys';
 import type { UseHistoryBoardDataParams } from '@/app/(service)/myhistory/types';
 import {
-  getHistorySections,
-  getHistorySummaryData,
+  buildHistoryDateSections,
+  buildHistorySummaryData,
 } from '@/app/(service)/myhistory/utils/myHistoryData';
 
 export default function useHistoryBoardData({
@@ -50,12 +50,13 @@ export default function useHistoryBoardData({
   });
 
   const historySections = useMemo(
-    () => getHistorySections(completedTasks, taskListSources, activeFilterId),
+    () =>
+      buildHistoryDateSections(completedTasks, taskListSources, activeFilterId),
     [activeFilterId, completedTasks, taskListSources],
   );
 
   const summaryData = useMemo(
-    () => getHistorySummaryData(currentUserId, teamDetails, taskListSources),
+    () => buildHistorySummaryData(currentUserId, teamDetails, taskListSources),
     [currentUserId, taskListSources, teamDetails],
   );
 

--- a/src/app/(service)/myhistory/hooks/useHistoryMonthNavigator.ts
+++ b/src/app/(service)/myhistory/hooks/useHistoryMonthNavigator.ts
@@ -15,12 +15,35 @@ import {
 } from '@/app/(service)/myhistory/utils/formatHistoryDate';
 import type { DatePickerRangeValue } from '@/components/common/form/types';
 
+function createDraftRange(
+  endDate: Date | null,
+  startDate: Date | null,
+): MyHistoryDraftDateRange {
+  return {
+    endDate,
+    startDate,
+  };
+}
+
+function getRangeMonthLimit(
+  draftRange: MyHistoryDraftDateRange,
+  isSelectingEndDate: boolean,
+) {
+  if (!draftRange.startDate || !isSelectingEndDate) {
+    return {};
+  }
+
+  return {
+    maxDate: getMonthEndDate(draftRange.startDate),
+    minDate: getMonthStartDate(draftRange.startDate),
+  };
+}
+
 export default function useHistoryMonthNavigator({
   closeCalendar,
   isCalendarOpen,
   onApplyRange,
   onMoveMonth,
-  onResetRange,
   selectedRange,
   toggleCalendar,
 }: UseHistoryMonthNavigatorParams) {
@@ -31,29 +54,21 @@ export default function useHistoryMonthNavigator({
   const isSelectingEndDate = Boolean(
     draftRange.startDate && !draftRange.endDate,
   );
-
-  const rangeMonthLimit = useMemo(() => {
-    if (!draftRange.startDate || !isSelectingEndDate) return {};
-
-    return {
-      maxDate: getMonthEndDate(draftRange.startDate),
-      minDate: getMonthStartDate(draftRange.startDate),
-    };
-  }, [draftRange.startDate, isSelectingEndDate]);
+  const rangeMonthLimit = useMemo(
+    () => getRangeMonthLimit(draftRange, isSelectingEndDate),
+    [draftRange, isSelectingEndDate],
+  );
 
   const handleRangeChange = (nextRange: DatePickerRangeValue) => {
     const [nextStartDate, nextEndDate] = nextRange;
 
     if (!nextStartDate) {
-      setDraftRange({ endDate: null, startDate: null });
+      setDraftRange(createDraftRange(null, null));
       return;
     }
 
     if (!nextEndDate) {
-      setDraftRange({
-        endDate: null,
-        startDate: nextStartDate,
-      });
+      setDraftRange(createDraftRange(null, nextStartDate));
       return;
     }
 
@@ -72,22 +87,15 @@ export default function useHistoryMonthNavigator({
     onMoveMonth(monthOffset);
   };
 
+  const syncDraftRangeWithSelectedRange = () => {
+    setDraftRange(
+      createDraftRange(selectedRange.endDate, selectedRange.startDate),
+    );
+  };
+
   const handleToggleCalendar = () => {
     if (!isCalendarOpen) {
-      if (selectedRange.mode === 'range') {
-        setDraftRange({
-          endDate: null,
-          startDate: null,
-        });
-        onResetRange();
-        toggleCalendar();
-        return;
-      }
-
-      setDraftRange({
-        endDate: selectedRange.endDate,
-        startDate: selectedRange.startDate,
-      });
+      syncDraftRangeWithSelectedRange();
     }
 
     toggleCalendar();

--- a/src/app/(service)/myhistory/hooks/useHistorySelectedRange.ts
+++ b/src/app/(service)/myhistory/hooks/useHistorySelectedRange.ts
@@ -1,0 +1,75 @@
+/**
+ * 내 히스토리 화면의 선택된 날짜 범위 상태와 범위 변경 액션을 관리하는 훅입니다.
+ */
+
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { MY_HISTORY_DATE_RANGE_MODES } from '@/app/(service)/myhistory/constants';
+import type {
+  MyHistoryDateRange,
+  MyHistoryResolvedDateRange,
+} from '@/app/(service)/myhistory/types';
+import {
+  addMonths,
+  createHistoryAllRange,
+  createHistoryMonthRange,
+  formatHistoryRangeTitle,
+} from '@/app/(service)/myhistory/utils/formatHistoryDate';
+
+type UseHistorySelectedRangeParams = {
+  defaultAnchorDate: Date;
+};
+
+export default function useHistorySelectedRange({
+  defaultAnchorDate,
+}: UseHistorySelectedRangeParams) {
+  const [selectedRangeOverride, setSelectedRangeOverride] =
+    useState<MyHistoryDateRange | null>(null);
+  const selectedRange = useMemo(() => {
+    if (selectedRangeOverride) {
+      return selectedRangeOverride;
+    }
+
+    return createHistoryAllRange(defaultAnchorDate);
+  }, [defaultAnchorDate, selectedRangeOverride]);
+  const isAllRange = selectedRange.mode === MY_HISTORY_DATE_RANGE_MODES.ALL;
+
+  const handleApplyRange = ({
+    endDate,
+    startDate,
+  }: MyHistoryResolvedDateRange) => {
+    setSelectedRangeOverride({
+      endDate,
+      mode: MY_HISTORY_DATE_RANGE_MODES.RANGE,
+      startDate,
+    });
+  };
+
+  const handleMoveMonth = (monthOffset: number) => {
+    setSelectedRangeOverride((prevRange) =>
+      createHistoryMonthRange(
+        addMonths(
+          prevRange?.mode === MY_HISTORY_DATE_RANGE_MODES.ALL
+            ? defaultAnchorDate
+            : (prevRange?.startDate ?? defaultAnchorDate),
+          monthOffset,
+        ),
+      ),
+    );
+  };
+
+  const handleResetRange = () => {
+    setSelectedRangeOverride(null);
+  };
+
+  return {
+    handleApplyRange,
+    handleMoveMonth,
+    handleResetRange,
+    isAllRange,
+    selectedRange,
+    title: formatHistoryRangeTitle(selectedRange),
+  } as const;
+}

--- a/src/app/(service)/myhistory/types.ts
+++ b/src/app/(service)/myhistory/types.ts
@@ -37,12 +37,15 @@ export type MyHistoryDraftDateRange = {
 };
 
 export type MyHistorySummaryDetail = {
+  doneCount: number;
   countText: string;
   id: string;
+  totalCount: number;
   title: string;
 };
 
 export type MyHistorySummaryItem = {
+  count: number;
   countText: string;
   details: MyHistorySummaryDetail[];
   id: string;

--- a/src/app/(service)/myhistory/types.ts
+++ b/src/app/(service)/myhistory/types.ts
@@ -8,6 +8,7 @@ import type {
   RefObject,
 } from 'react';
 
+import { MY_HISTORY_DATE_RANGE_MODES } from '@/app/(service)/myhistory/constants';
 import type { DatePickerRangeValue } from '@/components/common/form/types';
 
 export type MyHistoryFilter = {
@@ -18,7 +19,8 @@ export type MyHistoryFilter = {
 
 export type MyHistoryFilterId = 'once' | 'recurring';
 
-export type MyHistoryDateSelectionMode = 'all' | 'month' | 'range';
+export type MyHistoryDateSelectionMode =
+  (typeof MY_HISTORY_DATE_RANGE_MODES)[keyof typeof MY_HISTORY_DATE_RANGE_MODES];
 
 export type MyHistoryResolvedDateRange = {
   endDate: Date;
@@ -178,7 +180,6 @@ export type UseDragScrollReturn = {
 export type HistoryMonthNavigatorProps = {
   onApplyRange: (range: MyHistoryResolvedDateRange) => void;
   onMoveMonth: (monthOffset: number) => void;
-  onResetRange: () => void;
   selectedRange: MyHistoryDateRange;
   title: string;
 };
@@ -188,7 +189,6 @@ export type UseHistoryMonthNavigatorParams = {
   isCalendarOpen: boolean;
   onApplyRange: (range: MyHistoryResolvedDateRange) => void;
   onMoveMonth: (monthOffset: number) => void;
-  onResetRange: () => void;
   selectedRange: MyHistoryDateRange;
   toggleCalendar: () => void;
 };
@@ -203,7 +203,6 @@ export type HistoryBoardProps = {
   isProgressivelyLoading: boolean;
   onApplyRange: (range: MyHistoryResolvedDateRange) => void;
   onMoveMonth: (monthOffset: number) => void;
-  onResetRange: () => void;
   onSelectFilter: (filterId: string) => void;
   selectedRange: MyHistoryDateRange;
   title: string;

--- a/src/app/(service)/myhistory/utils/formatHistoryDate.ts
+++ b/src/app/(service)/myhistory/utils/formatHistoryDate.ts
@@ -2,6 +2,7 @@
  * 마이 히스토리 날짜 범위 생성과 표시 문자열 포맷을 담당하는 유틸입니다.
  */
 
+import { MY_HISTORY_DATE_RANGE_MODES } from '@/app/(service)/myhistory/constants';
 import type { MyHistoryDateRange } from '@/app/(service)/myhistory/types';
 export {
   addDays,
@@ -33,7 +34,7 @@ function padDay(day: number) {
 
 export function createHistoryMonthRange(
   date: Date,
-  mode: MyHistoryDateRange['mode'] = 'month',
+  mode: MyHistoryDateRange['mode'] = MY_HISTORY_DATE_RANGE_MODES.MONTH,
 ): MyHistoryDateRange {
   return {
     endDate: getMonthEndDate(date),
@@ -45,7 +46,7 @@ export function createHistoryMonthRange(
 export function createHistoryAllRange(date: Date): MyHistoryDateRange {
   return {
     endDate: date,
-    mode: 'all',
+    mode: MY_HISTORY_DATE_RANGE_MODES.ALL,
     startDate: date,
   };
 }
@@ -75,11 +76,14 @@ function isSameHistoryDay(firstDate: Date, secondDate: Date) {
 }
 
 export function getHistoryRangeTitleParts(range: MyHistoryDateRange) {
-  if (range.mode === 'all') {
+  if (range.mode === MY_HISTORY_DATE_RANGE_MODES.ALL) {
     return ['전체'] as const;
   }
 
-  if (range.mode === 'month' || isFullHistoryMonthRange(range)) {
+  if (
+    range.mode === MY_HISTORY_DATE_RANGE_MODES.MONTH ||
+    isFullHistoryMonthRange(range)
+  ) {
     return [formatHistoryMonth(range.startDate)] as const;
   }
 

--- a/src/app/(service)/myhistory/utils/getHistorySections.ts
+++ b/src/app/(service)/myhistory/utils/getHistorySections.ts
@@ -2,6 +2,7 @@
  * 히스토리 섹션을 날짜 범위에 맞게 필터링하고 화면 표시용으로 변환하는 유틸입니다.
  */
 
+import { MY_HISTORY_DATE_RANGE_MODES } from '@/app/(service)/myhistory/constants';
 import type {
   MyHistoryDateRange,
   MyHistoryDateSection,
@@ -21,33 +22,56 @@ export function hasHistoryTasks(
   );
 }
 
-export function getHistorySectionsInRange(
+type HistorySectionWithParsedDate = MyHistoryDisplayDateSection & {
+  parsedDate: Date;
+};
+
+function toDisplaySection(
+  section: MyHistoryDateSection,
+): HistorySectionWithParsedDate {
+  const parsedDate = parseHistoryDateKey(section.date);
+
+  return {
+    dateLabel: formatHistoryDate(parsedDate),
+    groups: section.groups,
+    id: section.id,
+    parsedDate,
+  };
+}
+
+function isSectionIncludedInRange(
+  section: HistorySectionWithParsedDate,
+  range: MyHistoryDateRange,
+) {
+  return range.mode === MY_HISTORY_DATE_RANGE_MODES.ALL
+    ? true
+    : isDateWithinHistoryRange(section.parsedDate, range);
+}
+
+function sortSectionsByLatestDate(
+  firstSection: HistorySectionWithParsedDate,
+  secondSection: HistorySectionWithParsedDate,
+) {
+  return secondSection.parsedDate.getTime() - firstSection.parsedDate.getTime();
+}
+
+function toSectionViewModel(
+  section: HistorySectionWithParsedDate,
+): MyHistoryDisplayDateSection {
+  return {
+    dateLabel: section.dateLabel,
+    groups: section.groups,
+    id: section.id,
+  };
+}
+
+export function buildVisibleHistorySections(
   sections: readonly MyHistoryDateSection[],
   range: MyHistoryDateRange,
 ) {
   return sections
-    .map((section) => {
-      const parsedDate = parseHistoryDateKey(section.date);
-
-      return {
-        ...section,
-        dateLabel: formatHistoryDate(parsedDate),
-        parsedDate,
-      };
-    })
-    .filter((section) =>
-      range.mode === 'all'
-        ? true
-        : isDateWithinHistoryRange(section.parsedDate, range),
-    )
-    .sort((firstSection, secondSection) => {
-      return (
-        secondSection.parsedDate.getTime() - firstSection.parsedDate.getTime()
-      );
-    })
-    .map((section) => ({
-      dateLabel: section.dateLabel,
-      groups: section.groups,
-      id: section.id,
-    }));
+    .map(toDisplaySection)
+    .filter((section) => isSectionIncludedInRange(section, range))
+    .sort(sortSectionsByLatestDate)
+    .map(toSectionViewModel);
 }

--- a/src/app/(service)/myhistory/utils/myHistoryData.ts
+++ b/src/app/(service)/myhistory/utils/myHistoryData.ts
@@ -6,8 +6,8 @@ export type {
   HistoryTaskListDetailSource,
   HistoryTeamDetail,
 } from '@/app/(service)/myhistory/types';
-export { getHistorySections } from '@/app/(service)/myhistory/utils/myHistorySectionBuilders';
-export { getHistorySummaryData } from '@/app/(service)/myhistory/utils/myHistorySummaryBuilders';
+export { buildHistoryDateSections } from '@/app/(service)/myhistory/utils/myHistorySectionBuilders';
+export { buildHistorySummaryData } from '@/app/(service)/myhistory/utils/myHistorySummaryBuilders';
 export {
   getCompletedTasksInRange,
   getLatestHistoryTaskDate,

--- a/src/app/(service)/myhistory/utils/myHistorySectionBuilderUtils.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySectionBuilderUtils.ts
@@ -1,0 +1,64 @@
+/**
+ * 완료 이력을 날짜 섹션과 주제 그룹으로 묶는 유틸입니다.
+ */
+
+import type {
+  HistoryTaskMeta,
+  MyHistoryCompletedTaskRecord,
+  MyHistoryDateSection,
+} from '@/app/(service)/myhistory/types';
+import { toHistoryTask } from '@/app/(service)/myhistory/utils/myHistorySectionUtils';
+import { toSectionDateKey } from '@/app/(service)/myhistory/utils/myHistoryTaskDateHelpers';
+
+type HistoryTaskMetaMap = ReadonlyMap<string, HistoryTaskMeta>;
+
+function createEmptyDateSection(sectionDateKey: string): MyHistoryDateSection {
+  return {
+    date: sectionDateKey,
+    groups: [],
+    id: sectionDateKey,
+  };
+}
+
+function buildHistoryGroupId(taskMeta?: HistoryTaskMeta) {
+  return `${taskMeta?.teamId ?? 'unknown'}-${taskMeta?.taskListId ?? 'unknown'}`;
+}
+
+export function buildHistoryDateSectionMap(
+  tasks: readonly MyHistoryCompletedTaskRecord[],
+  taskMetaMap: HistoryTaskMetaMap,
+) {
+  return tasks.reduce<Record<string, MyHistoryDateSection>>(
+    (sections, task) => {
+      const sectionDateKey = toSectionDateKey(task);
+
+      if (!sectionDateKey) {
+        return sections;
+      }
+
+      const section =
+        sections[sectionDateKey] ?? createEmptyDateSection(sectionDateKey);
+      const taskMeta = taskMetaMap.get(String(task.id ?? ''));
+      const groupId = buildHistoryGroupId(taskMeta);
+      const existingGroup = section.groups.find(
+        (group) => group.id === groupId,
+      );
+
+      if (existingGroup) {
+        existingGroup.tasks.push(toHistoryTask(task, taskMeta));
+      } else {
+        section.groups.push({
+          id: groupId,
+          tasks: [toHistoryTask(task, taskMeta)],
+          teamName: taskMeta?.teamName ?? '',
+          title: taskMeta?.taskListName ?? '완료',
+        });
+      }
+
+      sections[sectionDateKey] = section;
+
+      return sections;
+    },
+    {},
+  );
+}

--- a/src/app/(service)/myhistory/utils/myHistorySectionBuilders.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySectionBuilders.ts
@@ -1,99 +1,32 @@
 /**
- * 완료 이력을 날짜별, 주제별 히스토리 섹션 구조로 만드는 유틸입니다.
+ * 완료 이력을 날짜별, 주제별 히스토리 섹션 구조로 조합하는 유틸입니다.
  */
 
 import type {
   HistoryTaskListDetailSource,
   MyHistoryCompletedTaskRecord,
-  MyHistoryDateSection,
 } from '@/app/(service)/myhistory/types';
-import {
-  getTaskMetaMap,
-  toHistoryTask,
-} from '@/app/(service)/myhistory/utils/myHistorySectionUtils';
-import {
-  toSectionDateKey,
-  toTaskDate,
-} from '@/app/(service)/myhistory/utils/myHistoryTaskDateHelpers';
+import { buildHistoryDateSectionMap } from '@/app/(service)/myhistory/utils/myHistorySectionBuilderUtils';
+import { filterHistoryTasksByActiveTeam } from '@/app/(service)/myhistory/utils/myHistorySectionFilterUtils';
+import { sortHistoryTasksByDisplayOrder } from '@/app/(service)/myhistory/utils/myHistorySectionSortUtils';
+import { getTaskMetaMap } from '@/app/(service)/myhistory/utils/myHistorySectionUtils';
 
-export function getHistorySections(
+export function buildHistoryDateSections(
   completedTasks: readonly MyHistoryCompletedTaskRecord[],
   sources: readonly HistoryTaskListDetailSource[],
   activeTeamId: string | null,
 ) {
   const taskMetaMap = getTaskMetaMap(sources);
-  const visibleTasks = completedTasks
-    .filter((task) => {
-      if (!activeTeamId) {
-        return true;
-      }
-
-      const taskId =
-        typeof task.id === 'number' || typeof task.id === 'string'
-          ? String(task.id)
-          : null;
-
-      return taskId ? taskMetaMap.get(taskId)?.teamId === activeTeamId : false;
-    })
-    .sort((firstTask, secondTask) => {
-      const firstDate = toTaskDate(firstTask)?.getTime() ?? 0;
-      const secondDate = toTaskDate(secondTask)?.getTime() ?? 0;
-
-      if (firstDate !== secondDate) {
-        return firstDate - secondDate;
-      }
-
-      const firstMeta = taskMetaMap.get(String(firstTask.id ?? ''));
-      const secondMeta = taskMetaMap.get(String(secondTask.id ?? ''));
-
-      if (
-        (firstMeta?.taskListDisplayIndex ?? 0) !==
-        (secondMeta?.taskListDisplayIndex ?? 0)
-      ) {
-        return (
-          (firstMeta?.taskListDisplayIndex ?? 0) -
-          (secondMeta?.taskListDisplayIndex ?? 0)
-        );
-      }
-
-      return (firstTask.displayIndex ?? 0) - (secondTask.displayIndex ?? 0);
-    });
-
-  const sectionsByDate = visibleTasks.reduce<
-    Record<string, MyHistoryDateSection>
-  >((sections, task) => {
-    const sectionDateKey = toSectionDateKey(task);
-
-    if (!sectionDateKey) {
-      return sections;
-    }
-
-    const section =
-      sections[sectionDateKey] ??
-      ({
-        date: sectionDateKey,
-        groups: [],
-        id: sectionDateKey,
-      } satisfies MyHistoryDateSection);
-    const taskMeta = taskMetaMap.get(String(task.id ?? ''));
-    const groupId = `${taskMeta?.teamId ?? 'unknown'}-${taskMeta?.taskListId ?? 'unknown'}`;
-    const existingGroup = section.groups.find((group) => group.id === groupId);
-
-    if (existingGroup) {
-      existingGroup.tasks.push(toHistoryTask(task, taskMeta));
-    } else {
-      section.groups.push({
-        id: groupId,
-        tasks: [toHistoryTask(task, taskMeta)],
-        teamName: taskMeta?.teamName ?? '',
-        title: taskMeta?.taskListName ?? '완료',
-      });
-    }
-
-    sections[sectionDateKey] = section;
-
-    return sections;
-  }, {});
+  const teamVisibleTasks = filterHistoryTasksByActiveTeam(
+    completedTasks,
+    activeTeamId,
+    taskMetaMap,
+  );
+  const sortedTasks = sortHistoryTasksByDisplayOrder(
+    teamVisibleTasks,
+    taskMetaMap,
+  );
+  const sectionsByDate = buildHistoryDateSectionMap(sortedTasks, taskMetaMap);
 
   return Object.values(sectionsByDate);
 }

--- a/src/app/(service)/myhistory/utils/myHistorySectionFilterUtils.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySectionFilterUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * 선택된 팀 기준으로 완료 이력 작업 목록을 거르는 유틸입니다.
+ */
+
+import type {
+  HistoryTaskMeta,
+  MyHistoryCompletedTaskRecord,
+} from '@/app/(service)/myhistory/types';
+
+type HistoryTaskMetaMap = ReadonlyMap<string, HistoryTaskMeta>;
+
+function toHistoryTaskId(task: MyHistoryCompletedTaskRecord) {
+  return typeof task.id === 'number' || typeof task.id === 'string'
+    ? String(task.id)
+    : null;
+}
+
+export function filterHistoryTasksByActiveTeam(
+  completedTasks: readonly MyHistoryCompletedTaskRecord[],
+  activeTeamId: string | null,
+  taskMetaMap: HistoryTaskMetaMap,
+) {
+  if (!activeTeamId) {
+    return completedTasks;
+  }
+
+  return completedTasks.filter((task) => {
+    const taskId = toHistoryTaskId(task);
+
+    return taskId ? taskMetaMap.get(taskId)?.teamId === activeTeamId : false;
+  });
+}

--- a/src/app/(service)/myhistory/utils/myHistorySectionSortUtils.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySectionSortUtils.ts
@@ -1,0 +1,61 @@
+/**
+ * 히스토리 날짜 섹션 안에서 완료 이력을 읽기 좋은 순서로 정렬하는 유틸입니다.
+ */
+
+import type {
+  HistoryTaskMeta,
+  MyHistoryCompletedTaskRecord,
+} from '@/app/(service)/myhistory/types';
+import { toTaskDate } from '@/app/(service)/myhistory/utils/myHistoryTaskDateHelpers';
+
+type HistoryTaskMetaMap = ReadonlyMap<string, HistoryTaskMeta>;
+
+function compareByCompletedAt(
+  firstTask: MyHistoryCompletedTaskRecord,
+  secondTask: MyHistoryCompletedTaskRecord,
+) {
+  const firstDate = toTaskDate(firstTask)?.getTime() ?? 0;
+  const secondDate = toTaskDate(secondTask)?.getTime() ?? 0;
+
+  return firstDate - secondDate;
+}
+
+function compareByTaskListOrder(
+  firstMeta: HistoryTaskMeta | undefined,
+  secondMeta: HistoryTaskMeta | undefined,
+) {
+  return (
+    (firstMeta?.taskListDisplayIndex ?? 0) -
+    (secondMeta?.taskListDisplayIndex ?? 0)
+  );
+}
+
+function compareByTaskOrder(
+  firstTask: MyHistoryCompletedTaskRecord,
+  secondTask: MyHistoryCompletedTaskRecord,
+) {
+  return (firstTask.displayIndex ?? 0) - (secondTask.displayIndex ?? 0);
+}
+
+export function sortHistoryTasksByDisplayOrder(
+  tasks: readonly MyHistoryCompletedTaskRecord[],
+  taskMetaMap: HistoryTaskMetaMap,
+) {
+  return [...tasks].sort((firstTask, secondTask) => {
+    const completedAtOrder = compareByCompletedAt(firstTask, secondTask);
+
+    if (completedAtOrder !== 0) {
+      return completedAtOrder;
+    }
+
+    const firstMeta = taskMetaMap.get(String(firstTask.id ?? ''));
+    const secondMeta = taskMetaMap.get(String(secondTask.id ?? ''));
+    const taskListOrder = compareByTaskListOrder(firstMeta, secondMeta);
+
+    if (taskListOrder !== 0) {
+      return taskListOrder;
+    }
+
+    return compareByTaskOrder(firstTask, secondTask);
+  });
+}

--- a/src/app/(service)/myhistory/utils/myHistorySummaryBuilderUtils.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySummaryBuilderUtils.ts
@@ -78,16 +78,22 @@ export function buildTeamSummaryCards(
       const matchedTaskListSummary = matchedTeamSummary?.details.get(
         taskList.id,
       );
+      const doneCount = matchedTaskListSummary?.doneCount ?? 0;
+      const totalCount = matchedTaskListSummary?.totalCount ?? 0;
 
       return {
-        countText: `${matchedTaskListSummary?.doneCount ?? 0}/${matchedTaskListSummary?.totalCount ?? 0}`,
+        doneCount,
+        countText: `${doneCount}/${totalCount}`,
         id: taskList.id,
+        totalCount,
         title: taskList.name,
       };
     });
+    const doneCount = matchedTeamSummary?.doneCount ?? 0;
 
     return {
-      countText: `${matchedTeamSummary?.doneCount ?? 0}개`,
+      count: doneCount,
+      countText: `${doneCount}개`,
       details,
       id: teamDetail.id,
       title: teamDetail.name,
@@ -101,7 +107,7 @@ export function buildHistoryTeamFilters(
   return summaryItems.map(
     (item) =>
       ({
-        count: Number(item.countText.replace('개', '')) || 0,
+        count: item.count,
         id: item.id,
         label: item.title,
       }) satisfies MyHistoryFilter,

--- a/src/app/(service)/myhistory/utils/myHistorySummaryBuilderUtils.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySummaryBuilderUtils.ts
@@ -1,0 +1,109 @@
+/**
+ * 팀별 완료 요약 카드와 필터 계산에 필요한 세부 유틸입니다.
+ */
+
+import type {
+  HistorySummaryAccumulator,
+  HistoryTaskListDetailSource,
+  HistoryTeamDetail,
+  MyHistoryFilter,
+  MyHistorySummaryItem,
+} from '@/app/(service)/myhistory/types';
+
+function countCompletedTasksForCurrentUser(
+  currentUserId: number | string | undefined,
+  source: HistoryTaskListDetailSource,
+) {
+  return source.tasks.filter((task) =>
+    currentUserId !== undefined
+      ? String(task.doneByUserId) === String(currentUserId)
+      : Boolean(task.doneAt),
+  ).length;
+}
+
+function createEmptyTeamSummary(source: HistoryTaskListDetailSource) {
+  return {
+    details: new Map(),
+    doneCount: 0,
+    name: source.teamName,
+  } satisfies HistorySummaryAccumulator;
+}
+
+function createEmptyTaskListSummary(source: HistoryTaskListDetailSource) {
+  return {
+    displayIndex: source.displayIndex,
+    doneCount: 0,
+    name: source.taskListName,
+    totalCount: 0,
+  } as const;
+}
+
+export function accumulateTeamSummariesFromTaskLists(
+  currentUserId: number | string | undefined,
+  sources: readonly HistoryTaskListDetailSource[],
+) {
+  return sources.reduce<Map<string, HistorySummaryAccumulator>>(
+    (summaries, source) => {
+      const teamSummary =
+        summaries.get(source.teamId) ?? createEmptyTeamSummary(source);
+      const taskListSummary =
+        teamSummary.details.get(source.taskListId) ??
+        createEmptyTaskListSummary(source);
+      const completedCount = countCompletedTasksForCurrentUser(
+        currentUserId,
+        source,
+      );
+
+      taskListSummary.doneCount += completedCount;
+      taskListSummary.totalCount += source.tasks.length;
+      teamSummary.doneCount += completedCount;
+      teamSummary.details.set(source.taskListId, {
+        ...taskListSummary,
+      });
+      summaries.set(source.teamId, teamSummary);
+
+      return summaries;
+    },
+    new Map(),
+  );
+}
+
+export function buildTeamSummaryCards(
+  teamDetails: readonly HistoryTeamDetail[],
+  teamSummaryMap: ReadonlyMap<string, HistorySummaryAccumulator>,
+) {
+  return teamDetails.map((teamDetail) => {
+    const matchedTeamSummary = teamSummaryMap.get(teamDetail.id);
+    const details = teamDetail.taskLists.map((taskList) => {
+      const matchedTaskListSummary = matchedTeamSummary?.details.get(
+        taskList.id,
+      );
+
+      return {
+        countText: `${matchedTaskListSummary?.doneCount ?? 0}/${matchedTaskListSummary?.totalCount ?? 0}`,
+        id: taskList.id,
+        title: taskList.name,
+      };
+    });
+
+    return {
+      countText: `${matchedTeamSummary?.doneCount ?? 0}개`,
+      details,
+      id: teamDetail.id,
+      title: teamDetail.name,
+    };
+  });
+}
+
+export function buildHistoryTeamFilters(
+  summaryItems: readonly MyHistorySummaryItem[],
+) {
+  return summaryItems.map(
+    (item) =>
+      ({
+        count: Number(item.countText.replace('개', '')) || 0,
+        id: item.id,
+        label: item.title,
+      }) satisfies MyHistoryFilter,
+  );
+}

--- a/src/app/(service)/myhistory/utils/myHistorySummaryBuilders.ts
+++ b/src/app/(service)/myhistory/utils/myHistorySummaryBuilders.ts
@@ -1,86 +1,30 @@
 /**
- * 팀별 요약 카드와 필터 데이터를 만드는 유틸입니다.
+ * 내 히스토리 왼쪽 요약 카드와 팀 필터 목록을 조합하는 유틸입니다.
  */
 
 import type {
-  HistorySummaryAccumulator,
   HistoryTaskListDetailSource,
   HistoryTeamDetail,
-  MyHistoryFilter,
-  MyHistorySummaryItem,
 } from '@/app/(service)/myhistory/types';
+import {
+  accumulateTeamSummariesFromTaskLists,
+  buildHistoryTeamFilters,
+  buildTeamSummaryCards,
+} from '@/app/(service)/myhistory/utils/myHistorySummaryBuilderUtils';
 
-export function getHistorySummaryData(
+export function buildHistorySummaryData(
   currentUserId: number | string | undefined,
   teamDetails: readonly HistoryTeamDetail[],
   sources: readonly HistoryTaskListDetailSource[],
 ) {
-  const teamSummaries = sources.reduce<Map<string, HistorySummaryAccumulator>>(
-    (summaries, source) => {
-      const teamSummary =
-        summaries.get(source.teamId) ??
-        ({
-          details: new Map(),
-          doneCount: 0,
-          name: source.teamName,
-        } satisfies HistorySummaryAccumulator);
-      const detailSummary =
-        teamSummary.details.get(source.taskListId) ??
-        ({
-          displayIndex: source.displayIndex,
-          doneCount: 0,
-          name: source.taskListName,
-          totalCount: 0,
-        } as const);
-
-      const doneCount = source.tasks.filter((task) =>
-        currentUserId !== undefined
-          ? String(task.doneByUserId) === String(currentUserId)
-          : Boolean(task.doneAt),
-      ).length;
-
-      detailSummary.doneCount += doneCount;
-      detailSummary.totalCount += source.tasks.length;
-      teamSummary.doneCount += doneCount;
-      teamSummary.details.set(source.taskListId, {
-        ...detailSummary,
-      });
-      summaries.set(source.teamId, teamSummary);
-
-      return summaries;
-    },
-    new Map(),
+  const teamSummaryMap = accumulateTeamSummariesFromTaskLists(
+    currentUserId,
+    sources,
   );
-
-  const items = teamDetails.map((teamDetail) => {
-    const teamSummary = teamSummaries.get(teamDetail.id);
-    const details = teamDetail.taskLists.map((taskList) => {
-      const detail = teamSummary?.details.get(taskList.id);
-
-      return {
-        countText: `${detail?.doneCount ?? 0}/${detail?.totalCount ?? 0}`,
-        id: taskList.id,
-        title: taskList.name,
-      };
-    });
-
-    return {
-      countText: `${teamSummary?.doneCount ?? 0}개`,
-      details,
-      id: teamDetail.id,
-      title: teamDetail.name,
-    };
-  });
+  const items = buildTeamSummaryCards(teamDetails, teamSummaryMap);
 
   return {
-    filters: items.map(
-      (item) =>
-        ({
-          count: Number(item.countText.replace('개', '')) || 0,
-          id: item.id,
-          label: item.title,
-        }) satisfies MyHistoryFilter,
-    ),
-    items: items satisfies MyHistorySummaryItem[],
+    filters: buildHistoryTeamFilters(items),
+    items,
   };
 }

--- a/src/app/(service)/oauth/signup/[provider]/hooks/useOauthSignupPage.ts
+++ b/src/app/(service)/oauth/signup/[provider]/hooks/useOauthSignupPage.ts
@@ -5,8 +5,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { OAUTH_SIGNUP_TEXT } from '@/app/(service)/oauth/signup/[provider]/constants';
-import { ROUTES } from '@/constants/ROUTES';
 import { useSignInWithOauthMutation } from '@/hooks/useAuth';
+import { buildLoginPath, resolvePostAuthPath } from '@/utils/authRedirect';
 import { extractAuthSession, saveAuthSession } from '@/utils/authSession';
 
 const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
@@ -52,7 +52,7 @@ export default function useOauthSignupPage({
       }
 
       saveAuthSession(session);
-      router.replace(TEAM_ID ? ROUTES.TEAM(TEAM_ID) : ROUTES.HOME);
+      router.replace(resolvePostAuthPath(TEAM_ID, state));
     },
   });
   const initialErrorMessage =
@@ -109,7 +109,7 @@ export default function useOauthSignupPage({
   return {
     errorMessage: mutationErrorMessage || initialErrorMessage,
     handleGoLogin: () => {
-      router.replace(ROUTES.LOGIN);
+      router.replace(buildLoginPath({ redirectTo: state }));
     },
     isPending: signInWithOauthMutation.isPending,
   };

--- a/src/app/(service)/signup/components/SignupForm.tsx
+++ b/src/app/(service)/signup/components/SignupForm.tsx
@@ -2,15 +2,21 @@
 
 import Link from 'next/link';
 
-import { SIGNUP_LINKS, SIGNUP_TEXT } from '@/app/(service)/signup/constants';
+import { SIGNUP_TEXT } from '@/app/(service)/signup/constants';
 import useSignupForm from '@/app/(service)/signup/hooks/useSignupForm';
-import { IcKakaotalk } from '@/assets';
 import { PrimaryButton } from '@/components/common/button';
-import { AuthInput } from '@/components/common/form';
-import FullLogo from '@/components/common/logo/FullLogo';
-import { ROUTES } from '@/constants/ROUTES';
+import {
+  AuthInput,
+  AuthSocialSection,
+  AuthTitleBlock,
+} from '@/components/common/form';
+import { buildLoginPath } from '@/utils/authRedirect';
 
-export default function SignupForm() {
+type SignupFormProps = {
+  redirectTo?: string;
+};
+
+export default function SignupForm({ redirectTo }: SignupFormProps) {
   const {
     emailField,
     emailError,
@@ -23,22 +29,11 @@ export default function SignupForm() {
     passwordError,
     serverError,
     handleSubmit,
-  } = useSignupForm();
+  } = useSignupForm({ redirectTo });
 
   return (
     <section className="mx-auto w-full max-w-lg rounded-[20px] bg-background-inverse px-5.25 py-9.25 md:px-8 md:py-12.5">
-      <h1 className="mb-8 flex justify-center md:mb-10">
-        <Link href={ROUTES.HOME} aria-label="Coworkers 홈으로 이동">
-          <FullLogo
-            size="auth"
-            className="origin-center scale-90 md:scale-100"
-          />
-        </Link>
-      </h1>
-
-      <h2 className="mb-6 text-center text-base font-semibold text-text-primary md:mb-8 md:text-lg">
-        {SIGNUP_TEXT.title}
-      </h2>
+      <AuthTitleBlock title={SIGNUP_TEXT.title} />
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-5 md:px-6">
         <AuthInput
@@ -90,39 +85,14 @@ export default function SignupForm() {
       <p className="mt-6 text-center text-sm text-text-secondary">
         {SIGNUP_TEXT.loginGuide}
         <Link
-          href={SIGNUP_LINKS.login}
+          href={buildLoginPath({ redirectTo })}
           className="ml-1 font-medium text-brand-primary underline"
         >
           {SIGNUP_TEXT.loginLink}
         </Link>
       </p>
 
-      <div className="mx-auto mt-10 flex w-full max-w-md items-center gap-4 md:px-6">
-        <div className="h-px flex-1 bg-background-tertiary" />
-        <span className="text-sm text-text-secondary">
-          {SIGNUP_TEXT.divider}
-        </span>
-        <div className="h-px flex-1 bg-background-tertiary" />
-      </div>
-
-      <button
-        type="button"
-        onClick={() => {
-          window.location.assign(ROUTES.OAUTH_AUTHORIZE('kakao'));
-        }}
-        className="mx-auto mt-4 flex h-11 w-full max-w-md items-center justify-between md:px-6 "
-      >
-        <span className="text-sm text-text-secondary">
-          {SIGNUP_TEXT.kakaoSignUp}
-        </span>
-        <IcKakaotalk
-          width={44}
-          height={44}
-          className="h-11 w-11 cursor-pointer"
-          role="img"
-          aria-label="카카오 아이콘"
-        />
-      </button>
+      <AuthSocialSection mode="signup" redirectTo={redirectTo} />
     </section>
   );
 }

--- a/src/app/(service)/signup/components/SignupPageContent.tsx
+++ b/src/app/(service)/signup/components/SignupPageContent.tsx
@@ -2,14 +2,18 @@
  * 회원가입 페이지의 전체 배치를 렌더링하는 컴포넌트입니다.
  */
 
-'use client';
-
 import SignupForm from '@/app/(service)/signup/components/SignupForm';
 
-export default function SignupPageContent() {
+type SignupPageContentProps = {
+  redirectTo?: string;
+};
+
+export default function SignupPageContent({
+  redirectTo,
+}: SignupPageContentProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background-secondary px-4 py-10">
-      <SignupForm />
+      <SignupForm redirectTo={redirectTo} />
     </div>
   );
 }

--- a/src/app/(service)/signup/constants.ts
+++ b/src/app/(service)/signup/constants.ts
@@ -1,5 +1,3 @@
-import { ROUTES } from '@/constants/ROUTES';
-
 export const SIGNUP_TEXT = {
   title: '회원가입',
   nicknameLabel: '닉네임',
@@ -13,10 +11,4 @@ export const SIGNUP_TEXT = {
   signupButton: '가입하기',
   loginGuide: '이미 계정이 있으신가요?',
   loginLink: '로그인하기',
-  divider: 'OR',
-  kakaoSignUp: '카카오로 회원가입하기',
-} as const;
-
-export const SIGNUP_LINKS = {
-  login: ROUTES.LOGIN,
 } as const;

--- a/src/app/(service)/signup/hooks/useAutoSignInAfterSignup.ts
+++ b/src/app/(service)/signup/hooks/useAutoSignInAfterSignup.ts
@@ -1,0 +1,78 @@
+/**
+ * 회원가입 직후 자동 로그인을 처리하는 훅입니다.
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useToast } from '@/components/common/toast';
+import { useSignInMutation } from '@/hooks/useAuth';
+import { buildLoginPath, resolvePostAuthPath } from '@/utils/authRedirect';
+import { extractAuthSession, saveAuthSession } from '@/utils/authSession';
+
+const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
+
+type UseAutoSignInAfterSignupParams = {
+  redirectTo?: string;
+};
+
+type HandleSignUpSuccessParams = {
+  email: string;
+  password: string;
+  teamId: string;
+};
+
+export default function useAutoSignInAfterSignup({
+  redirectTo,
+}: UseAutoSignInAfterSignupParams) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const signInMutation = useSignInMutation({
+    onError: (_, variables) => {
+      showToast(
+        '가입은 완료되었지만 자동 로그인에 실패했습니다. 비밀번호를 입력해 로그인해주세요.',
+        'error',
+      );
+      router.push(
+        buildLoginPath({
+          email: variables.body.email,
+          redirectTo,
+        }),
+      );
+    },
+    onSuccess: (data) => {
+      const session = extractAuthSession(data);
+
+      if (!session) {
+        showToast(
+          '가입은 완료되었지만 자동 로그인에 실패했습니다. 다시 로그인해주세요.',
+          'error',
+        );
+        router.push(buildLoginPath({ redirectTo }));
+        return;
+      }
+
+      saveAuthSession(session);
+      showToast('가입과 로그인이 완료되었습니다.', 'success');
+      router.push(resolvePostAuthPath(TEAM_ID, redirectTo));
+    },
+  });
+
+  return {
+    handleSignUpSuccess: ({
+      email,
+      password,
+      teamId,
+    }: HandleSignUpSuccessParams) => {
+      signInMutation.mutate({
+        body: {
+          email,
+          password,
+        },
+        teamId,
+      });
+    },
+    isPending: signInMutation.isPending,
+  };
+}

--- a/src/app/(service)/signup/hooks/useSignupForm.ts
+++ b/src/app/(service)/signup/hooks/useSignupForm.ts
@@ -2,29 +2,33 @@
 
 import { useState } from 'react';
 
-import { useRouter } from 'next/navigation';
-
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, useWatch } from 'react-hook-form';
 
-import { useToast } from '@/components/common/toast';
-import { ROUTES } from '@/constants/ROUTES';
+import useAutoSignInAfterSignup from '@/app/(service)/signup/hooks/useAutoSignInAfterSignup';
 import { useSignUpMutation } from '@/hooks/useAuth';
 import { signUpFormSchema, type SignUpFormValues } from '@/types/auth';
 
 const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
 
-export default function useSignupForm() {
-  const router = useRouter();
-  const { showToast } = useToast();
+type UseSignupFormParams = {
+  redirectTo?: string;
+};
+
+export default function useSignupForm({ redirectTo }: UseSignupFormParams) {
   const [serverError, setServerError] = useState('');
+  const { handleSignUpSuccess, isPending: isAutoSignInPending } =
+    useAutoSignInAfterSignup({ redirectTo });
   const signUpMutation = useSignUpMutation({
     onError: (error) => {
       setServerError(error.message);
     },
-    onSuccess: () => {
-      showToast('가입이 완료되었습니다.', 'success');
-      router.push(ROUTES.LOGIN);
+    onSuccess: (_, variables) => {
+      handleSignUpSuccess({
+        email: variables.body.email,
+        password: variables.body.password,
+        teamId: variables.teamId,
+      });
     },
   });
   const {
@@ -72,7 +76,8 @@ export default function useSignupForm() {
     emailError: errors.email?.message,
     emailField: register('email'),
     handleSubmit: handleSubmitForm,
-    isDisabled: !isSubmittable || signUpMutation.isPending,
+    isDisabled:
+      !isSubmittable || isAutoSignInPending || signUpMutation.isPending,
     nicknameError: errors.nickname?.message,
     nicknameField: register('nickname'),
     passwordConfirmationError: errors.passwordConfirmation?.message,

--- a/src/app/(service)/signup/page.tsx
+++ b/src/app/(service)/signup/page.tsx
@@ -4,6 +4,14 @@
 
 import SignupPageContent from '@/app/(service)/signup/components/SignupPageContent';
 
-export default function SignupPage() {
-  return <SignupPageContent />;
+type SignupPageProps = {
+  searchParams: Promise<{
+    redirectTo?: string;
+  }>;
+};
+
+export default async function SignupPage({ searchParams }: SignupPageProps) {
+  const { redirectTo } = await searchParams;
+
+  return <SignupPageContent redirectTo={redirectTo} />;
 }

--- a/src/app/api/oauth/[provider]/authorize/route.ts
+++ b/src/app/api/oauth/[provider]/authorize/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 import { ROUTES } from '@/constants/ROUTES';
+import { getSafeRedirectTo } from '@/utils/authRedirect';
 
 const SUPPORTED_OAUTH_PROVIDER = 'kakao';
 const KAKAO_PROFILE_SCOPES = ['profile_nickname', 'profile_image'];
@@ -26,11 +27,18 @@ export async function GET(
 
   const redirectUri = new URL(ROUTES.OAUTH_CALLBACK(provider), request.url);
   const authorizeUrl = new URL('https://kauth.kakao.com/oauth/authorize');
+  const redirectTo = getSafeRedirectTo(
+    request.nextUrl.searchParams.get('redirectTo'),
+  );
 
   authorizeUrl.searchParams.set('client_id', clientId);
   authorizeUrl.searchParams.set('redirect_uri', redirectUri.toString());
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('scope', KAKAO_PROFILE_SCOPES.join(','));
+
+  if (redirectTo) {
+    authorizeUrl.searchParams.set('state', redirectTo);
+  }
 
   return NextResponse.redirect(authorizeUrl);
 }

--- a/src/components/common/form/components/AuthInput.tsx
+++ b/src/components/common/form/components/AuthInput.tsx
@@ -57,8 +57,10 @@ export default function AuthInput({
           aria-describedby={hasError ? errorId : undefined}
           className={cn(
             'h-11 text-sm md:h-12 md:text-base',
-            isPasswordInput && 'pr-14 md:pr-16',
-            hasError && 'border-status-danger focus:border-status-danger',
+            {
+              'border-status-danger focus:border-status-danger': hasError,
+              'pr-14 md:pr-16': isPasswordInput,
+            },
             className,
           )}
           {...props}
@@ -72,7 +74,9 @@ export default function AuthInput({
             aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
             className={cn(
               'absolute right-4 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center md:size-6',
-              disabled && 'cursor-not-allowed opacity-40',
+              {
+                'cursor-not-allowed opacity-40': disabled,
+              },
             )}
           >
             {isPasswordVisible ? (

--- a/src/components/common/form/components/AuthSocialButton.tsx
+++ b/src/components/common/form/components/AuthSocialButton.tsx
@@ -1,0 +1,37 @@
+/**
+ * 로그인/회원가입 화면에서 사용하는 공통 소셜 인증 버튼입니다.
+ */
+
+import type { ComponentType, SVGProps } from 'react';
+
+type AuthSocialButtonProps = {
+  href: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  iconAlt: string;
+  iconSize: number;
+  label: string;
+};
+
+export default function AuthSocialButton({
+  href,
+  icon: Icon,
+  iconAlt,
+  iconSize,
+  label,
+}: AuthSocialButtonProps) {
+  return (
+    <a
+      href={href}
+      className="mx-auto mt-4 flex h-11 w-full max-w-md items-center justify-between md:px-6"
+    >
+      <span className="text-sm text-text-secondary">{label}</span>
+      <Icon
+        width={iconSize}
+        height={iconSize}
+        className="h-11 w-11"
+        role="img"
+        aria-label={iconAlt}
+      />
+    </a>
+  );
+}

--- a/src/components/common/form/components/AuthSocialSection.tsx
+++ b/src/components/common/form/components/AuthSocialSection.tsx
@@ -1,0 +1,38 @@
+/**
+ * 로그인/회원가입 화면의 공통 소셜 인증 영역입니다.
+ */
+
+import AuthSocialButton from '@/components/common/form/components/AuthSocialButton';
+import { AUTH_SOCIAL_PROVIDERS } from '@/constants/AUTH';
+import { buildOauthAuthorizePath } from '@/utils/authRedirect';
+
+type AuthSocialSectionProps = {
+  mode: 'login' | 'signup';
+  redirectTo?: string;
+};
+
+export default function AuthSocialSection({
+  mode,
+  redirectTo,
+}: AuthSocialSectionProps) {
+  return (
+    <>
+      <div className="mx-auto mt-10 flex w-full max-w-md items-center gap-4 md:px-6">
+        <div className="h-px flex-1 bg-background-tertiary" />
+        <span className="text-sm text-text-secondary">OR</span>
+        <div className="h-px flex-1 bg-background-tertiary" />
+      </div>
+
+      {AUTH_SOCIAL_PROVIDERS.map((provider) => (
+        <AuthSocialButton
+          key={provider.provider}
+          href={buildOauthAuthorizePath(provider.provider, redirectTo)}
+          icon={provider.icon}
+          iconAlt={provider.iconAlt}
+          iconSize={provider.iconSize}
+          label={mode === 'login' ? provider.loginLabel : provider.signupLabel}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/common/form/components/AuthTitleBlock.tsx
+++ b/src/components/common/form/components/AuthTitleBlock.tsx
@@ -1,0 +1,31 @@
+/**
+ * 로그인/회원가입 카드 상단 로고와 제목을 렌더링하는 공통 블록입니다.
+ */
+
+import Link from 'next/link';
+
+import FullLogo from '@/components/common/logo/FullLogo';
+import { ROUTES } from '@/constants/ROUTES';
+
+type AuthTitleBlockProps = {
+  title: string;
+};
+
+export default function AuthTitleBlock({ title }: AuthTitleBlockProps) {
+  return (
+    <>
+      <h1 className="mb-8 flex justify-center md:mb-10">
+        <Link href={ROUTES.HOME} aria-label="Coworkers 홈으로 이동">
+          <FullLogo
+            size="auth"
+            className="origin-center scale-90 md:scale-100"
+          />
+        </Link>
+      </h1>
+
+      <h2 className="mb-6 text-center text-base font-semibold text-text-primary md:mb-8 md:text-lg">
+        {title}
+      </h2>
+    </>
+  );
+}

--- a/src/components/common/form/index.tsx
+++ b/src/components/common/form/index.tsx
@@ -1,5 +1,8 @@
 export { default as Input } from '@/components/common/form/components/Input';
 export { default as AuthInput } from '@/components/common/form/components/AuthInput';
+export { default as AuthSocialButton } from '@/components/common/form/components/AuthSocialButton';
+export { default as AuthSocialSection } from '@/components/common/form/components/AuthSocialSection';
+export { default as AuthTitleBlock } from '@/components/common/form/components/AuthTitleBlock';
 export { default as TitleInput } from '@/components/common/form/components/TitleInput';
 export { default as ContentTextarea } from '@/components/common/form/components/ContentTextarea';
 export { default as CommentInput } from '@/components/common/form/components/CommentInput';

--- a/src/constants/AUTH.ts
+++ b/src/constants/AUTH.ts
@@ -1,0 +1,27 @@
+/**
+ * 로그인/회원가입 화면에서 공통으로 사용하는 소셜 인증 설정입니다.
+ */
+
+import type { ComponentType, SVGProps } from 'react';
+
+import { IcKakaotalk } from '@/assets';
+
+export type AuthSocialProvider = {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  iconAlt: string;
+  iconSize: number;
+  loginLabel: string;
+  provider: string;
+  signupLabel: string;
+};
+
+export const AUTH_SOCIAL_PROVIDERS = [
+  {
+    icon: IcKakaotalk,
+    iconAlt: '카카오 아이콘',
+    iconSize: 44,
+    loginLabel: '간편 로그인하기',
+    provider: 'kakao',
+    signupLabel: '카카오로 회원가입하기',
+  },
+] as const satisfies readonly AuthSocialProvider[];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
 const PUBLIC_PATH_PREFIXES = [
   ROUTES.LOGIN,
   ROUTES.SIGNUP,
+  ROUTES.BOARDS,
   '/oauth',
   '/reset-password',
   '/password-reset',

--- a/src/utils/authRedirect.ts
+++ b/src/utils/authRedirect.ts
@@ -8,6 +8,7 @@ const DUMMY_BASE_URL = 'https://coworkers.local';
 
 type BuildLoginPathParams = {
   email?: string;
+  notice?: 'auth-required';
   redirectTo?: string | null;
 };
 
@@ -38,10 +39,12 @@ export function getSafeRedirectTo(redirectTo?: string | null) {
 
 export function buildLoginPath({
   email,
+  notice,
   redirectTo,
 }: BuildLoginPathParams = {}) {
   return buildPathWithSearch(ROUTES.LOGIN, {
     email,
+    notice,
     redirectTo: getSafeRedirectTo(redirectTo),
   });
 }

--- a/src/utils/authRedirect.ts
+++ b/src/utils/authRedirect.ts
@@ -1,0 +1,72 @@
+/**
+ * 인증 전후 이동 경로를 안전하게 조합하는 유틸 파일입니다.
+ */
+
+import { ROUTES } from '@/constants/ROUTES';
+
+const DUMMY_BASE_URL = 'https://coworkers.local';
+
+type BuildLoginPathParams = {
+  email?: string;
+  redirectTo?: string | null;
+};
+
+function buildPathWithSearch(
+  pathname: string,
+  searchParams: Record<string, string | null | undefined>,
+) {
+  const url = new URL(pathname, DUMMY_BASE_URL);
+
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (!value) {
+      return;
+    }
+
+    url.searchParams.set(key, value);
+  });
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function getSafeRedirectTo(redirectTo?: string | null) {
+  if (!redirectTo?.startsWith('/')) {
+    return null;
+  }
+
+  return redirectTo.startsWith('//') ? null : redirectTo;
+}
+
+export function buildLoginPath({
+  email,
+  redirectTo,
+}: BuildLoginPathParams = {}) {
+  return buildPathWithSearch(ROUTES.LOGIN, {
+    email,
+    redirectTo: getSafeRedirectTo(redirectTo),
+  });
+}
+
+export function buildSignupPath(redirectTo?: string | null) {
+  return buildPathWithSearch(ROUTES.SIGNUP, {
+    redirectTo: getSafeRedirectTo(redirectTo),
+  });
+}
+
+export function buildOauthAuthorizePath(
+  provider: string,
+  redirectTo?: string | null,
+) {
+  return buildPathWithSearch(ROUTES.OAUTH_AUTHORIZE(provider), {
+    redirectTo: getSafeRedirectTo(redirectTo),
+  });
+}
+
+export function resolvePostAuthPath(
+  teamId: string | undefined,
+  redirectTo?: string | null,
+) {
+  return (
+    getSafeRedirectTo(redirectTo) ??
+    (teamId ? ROUTES.TEAM(teamId) : ROUTES.HOME)
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #148 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 가입하면 자동으로 로그인 되서 대시보드로 이동하게 하는게 좋을듯 아니면 그냥 아이디가 회원가입 하면 채워져 있고 비번만 치게?
- signup → page 에서 use client 제거하기 (다른 페이지도 마찬가지로 굳이 use client가 들어갈 필요가 없다면 제거하기)
- AuthInput → 지금도 좋지만, kakao를 배열로 관리하는 경우가 많음 이렇게 되면 구조를 변경할 필요없이 구글이 만약 추가된다고 하면 배열에 구글만 추가하면 됨
- 채용 홍보 페이지 에서 로그인을 하지 않고 보다가 댓글을 남기려고 했는데 안되서 가입하고 다시 원래 보던 페이지로 이동하게 하면 사용자 입장에서 편할꺼임 나중에 구현할 수 있다면 구현 하면 좋을거 같음 카카오톡으로 로그인도 마찬가지
- 비밀번호 찾기 할때 내가 가입한 이메일이 아니면 보내주는 경고 문구 수정해야 할듯
- 달력을 기간을 설정하고 달력을 다시 눌렀을때 초기화되서 전체가 보이는게 좀 어색할 수 있을거 같아서 기간은 유지되게 하고 그냥 다른 버튼, 팀 등 이런 해당 팀 리스트이외의 것에 접근하는 상황에만 전체로 초기화 되게 해줘
- useHistoryBoard 에서 상수화 시킬 수 있는 부분 상수화 시키기 ex) selectedRange
- 내히스토리  myHistorySetionBuilder→ getHistorySections 함수가 좀 큰거 같아서 이거를 조금 더 읽기 좋게 리펙토링 하면 좋을거 같음 filter,sort 들어가는 부분들을 특히 리펙토링 해주면 좋을거 같음 함수명도 처음보는 사람이 이해하기 쉽게 바꾸기
- 내 히스토리 → myHistorySummaryBuilders → 이 부분도 마찬가지로 읽기 쉽게 디테일하게 명시해서 리펙토링
- 내 히스토리 → useHistoryMonthNavigator → 조건문이 중첩되는 부분을 중첩 없이 정리해서 사용하면 좋을듯


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
