### PR TITLE
[Refactor/#156]  접힌 사이드바 리스트 툴팁 추가

### DIFF
--- a/src/components/layout/sidebar/components/SidebarNavItem.tsx
+++ b/src/components/layout/sidebar/components/SidebarNavItem.tsx
@@ -19,6 +19,8 @@ export default function SidebarNavItem({
   variant = 'team',
 }: SidebarNavItemProps) {
   const isMenuVariant = variant === 'team' || variant === 'board';
+  const shouldShowCollapsedTooltip =
+    variant === 'team' && !isExpanded && !isMobileDrawer;
 
   const linkSizeClass = isMobileDrawer
     ? 'h-11 gap-4 rounded-lg px-5 text-sm hover:bg-background-secondary'
@@ -74,6 +76,7 @@ export default function SidebarNavItem({
         variant === 'addTeam' && addTeamSizeClass,
         linkToneClass,
       )}
+      aria-label={shouldShowCollapsedTooltip ? label : undefined}
       aria-current={isActive ? 'page' : undefined}
       onClick={onClick}
     >
@@ -93,7 +96,19 @@ export default function SidebarNavItem({
   );
 
   if (variant === 'team') {
-    return <li className={cn(isExpanded && 'w-full')}>{linkElement}</li>;
+    return (
+      <li className={cn('group relative', isExpanded && 'w-full')}>
+        {linkElement}
+        {shouldShowCollapsedTooltip && (
+          <span
+            role="tooltip"
+            className="pointer-events-none absolute left-full top-1/2 z-20 ml-3 -translate-y-1/2 translate-x-1 whitespace-nowrap rounded-lg bg-text-primary px-3 py-2 text-sm font-medium text-text-inverse opacity-0 shadow-lg invisible transition-all duration-200 group-hover:visible group-hover:translate-x-0 group-hover:opacity-100 motion-reduce:transition-none"
+          >
+            {label}
+          </span>
+        )}
+      </li>
+    );
   }
 
   return linkElement;

--- a/src/components/layout/sidebar/components/SidebarNavItem.tsx
+++ b/src/components/layout/sidebar/components/SidebarNavItem.tsx
@@ -102,7 +102,7 @@ export default function SidebarNavItem({
         {shouldShowCollapsedTooltip && (
           <span
             role="tooltip"
-            className="pointer-events-none absolute left-full top-1/2 z-20 ml-3 -translate-y-1/2 translate-x-1 whitespace-nowrap rounded-lg bg-text-primary px-3 py-2 text-sm font-medium text-text-inverse opacity-0 shadow-lg invisible transition-all duration-200 group-hover:visible group-hover:translate-x-0 group-hover:opacity-100 motion-reduce:transition-none"
+            className="pointer-events-none absolute left-full top-1/2 z-20 ml-3 -translate-y-1/2 translate-x-1 whitespace-nowrap rounded-lg bg-text-primary px-3 py-2 text-sm font-medium text-text-inverse opacity-0 shadow-lg invisible transition-all duration-200 group-hover:visible group-hover:translate-x-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-x-0 group-focus-within:opacity-100 motion-reduce:transition-none"
           >
             {label}
           </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #156 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사이드바가 접혔을때 팀 리스트에 호버시 툴팁을 추가해습니다.

### 스크린샷 (선택)

<img width="666" height="486" alt="image" src="https://github.com/user-attachments/assets/6e89d76b-2b64-433c-92cb-d890edf07447" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
