### PR TITLE
[Bug/#179] 내 히스토리 페이지 + 해더 사이드 + 오른쪽 패널 버그 수정

### DIFF
--- a/src/app/(service)/[teamid]/tasklist/components/TaskListSidebar.tsx
+++ b/src/app/(service)/[teamid]/tasklist/components/TaskListSidebar.tsx
@@ -65,7 +65,9 @@ export default function TaskListSidebar({
       aria-label="할 일 목록"
     >
       <div className="flex flex-col lg:hidden">
-        <p className="text-sm font-normal leading-5 text-text-default">할 일</p>
+        <p className="text-sm font-normal leading-5 text-text-default">
+          할 일 목록
+        </p>
         <div className="mt-2 flex min-w-0 w-full flex-row items-center justify-between gap-2">
           {isColumnListEmpty ? (
             <TaskListEmptyColumnPlaceholder />

--- a/src/app/(service)/[teamid]/tasklist/components/TaskListTaskRow.tsx
+++ b/src/app/(service)/[teamid]/tasklist/components/TaskListTaskRow.tsx
@@ -85,7 +85,7 @@ export default function TaskListTaskRow({
           className="shrink-0"
           items={[
             {
-              label: '수정하기',
+              label: '상세보기',
               onClick: () => {
                 handleOpenDetail();
               },

--- a/src/app/(service)/[teamid]/tasklist/hooks/useTaskListBoardQuery.ts
+++ b/src/app/(service)/[teamid]/tasklist/hooks/useTaskListBoardQuery.ts
@@ -4,20 +4,18 @@
 
 import { useCallback, useMemo, useState } from 'react';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { queryKeys } from '@/api/queryKeys';
 import { taskQueryOptions } from '@/api/queryOptions';
 import useTaskListRecurringWeekDaysQuery from '@/app/(service)/[teamid]/tasklist/hooks/useTaskListRecurringWeekDaysQuery';
 import type {
   TaskListBoardTask,
   UseTaskListBoardQueryParams,
 } from '@/app/(service)/[teamid]/tasklist/types';
-import { deleteTaskListBoardTask } from '@/app/(service)/[teamid]/tasklist/utils/deleteTaskListBoardTask';
 import { toTaskListDateString } from '@/app/(service)/[teamid]/tasklist/utils/taskListDate';
 import { formatTaskListRepeatLabel } from '@/app/(service)/[teamid]/tasklist/utils/taskListRepeatLabel';
 import { useToast } from '@/components/common/toast';
-import { useUpdateTaskMutation } from '@/hooks/useTask';
+import { useDeleteTaskMutation, useUpdateTaskMutation } from '@/hooks/useTask';
 
 export function useTaskListBoardQuery({
   groupId,
@@ -25,8 +23,8 @@ export function useTaskListBoardQuery({
   taskListId,
 }: UseTaskListBoardQueryParams) {
   const { showToast } = useToast();
-  const queryClient = useQueryClient();
   const updateTaskMutation = useUpdateTaskMutation();
+  const deleteTaskMutation = useDeleteTaskMutation();
   const dateString = toTaskListDateString(selectedDate);
 
   const { data: taskListDetail } = useQuery({
@@ -113,33 +111,17 @@ export function useTaskListBoardQuery({
   const handleConfirmDelete = useCallback(async () => {
     if (!taskPendingDelete || !groupId) return;
     try {
-      await deleteTaskListBoardTask(groupId, taskListId, taskPendingDelete);
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.taskList.detail(groupId, taskListId, {
-            date: dateString,
-          }),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.taskList.all(groupId),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.team.detail(groupId),
-        }),
-      ]);
+      await deleteTaskMutation.mutateAsync({
+        taskId: taskPendingDelete.id,
+        taskListId,
+        teamId: groupId,
+      });
       setTaskPendingDelete(null);
       showToast('삭제되었습니다.', 'error');
     } catch {
       // TODO: 에러 처리
     }
-  }, [
-    dateString,
-    taskPendingDelete,
-    groupId,
-    taskListId,
-    queryClient,
-    showToast,
-  ]);
+  }, [deleteTaskMutation, groupId, showToast, taskListId, taskPendingDelete]);
 
   return {
     handleCloseDeleteModal,

--- a/src/app/(service)/[teamid]/tasklist/utils/taskListQueryCache.ts
+++ b/src/app/(service)/[teamid]/tasklist/utils/taskListQueryCache.ts
@@ -58,6 +58,42 @@ export function syncCheckedTaskToTaskListDetail(
   };
 }
 
+export function removeTaskFromGroupDetail(
+  groupDetail: GroupDetail | undefined,
+  taskListId: string,
+  taskId: string,
+) {
+  if (!groupDetail) {
+    return groupDetail;
+  }
+
+  return {
+    ...groupDetail,
+    taskLists: groupDetail.taskLists.map((taskList) =>
+      String(taskList.id) === taskListId
+        ? {
+            ...taskList,
+            tasks: taskList.tasks.filter((task) => String(task.id) !== taskId),
+          }
+        : taskList,
+    ),
+  };
+}
+
+export function removeTaskFromTaskListDetail(
+  taskListDetail: TaskListDetail | undefined,
+  taskId: string,
+) {
+  if (!taskListDetail) {
+    return taskListDetail;
+  }
+
+  return {
+    ...taskListDetail,
+    tasks: taskListDetail.tasks.filter((task) => String(task.id) !== taskId),
+  };
+}
+
 export function removeTaskListFromGroupDetail(
   groupDetail: GroupDetail | undefined,
   taskListId: string,

--- a/src/app/(service)/myhistory/components/HistoryBoard.tsx
+++ b/src/app/(service)/myhistory/components/HistoryBoard.tsx
@@ -7,7 +7,6 @@ import HistoryFilterTabs from '@/app/(service)/myhistory/components/HistoryFilte
 import HistoryMonthNavigator from '@/app/(service)/myhistory/components/HistoryMonthNavigator';
 import { MY_HISTORY_BOARD_STATUS_TEXT } from '@/app/(service)/myhistory/constants';
 import type { HistoryBoardProps } from '@/app/(service)/myhistory/types';
-import { cn } from '@/utils/cn';
 
 export default function HistoryBoard({
   activeFilterId,
@@ -26,14 +25,7 @@ export default function HistoryBoard({
   title,
 }: HistoryBoardProps) {
   return (
-    <section
-      className={cn(
-        'w-full rounded-[20px] bg-background-inverse px-4.5 py-8 min-[411px]:px-6 md:px-13 md:py-13 2xl:w-189.5 2xl:shrink-0 2xl:px-9 2xl:py-12',
-        !hasTasks &&
-          !isLoading &&
-          'flex min-h-162.5 flex-col md:min-h-230 2xl:min-h-192',
-      )}
-    >
+    <section className="w-full rounded-[20px] bg-background-inverse px-4.5 py-8 min-[411px]:px-6 md:px-13 md:py-13 2xl:w-189.5 2xl:shrink-0 2xl:px-9 2xl:py-12">
       <HistoryMonthNavigator
         title={title}
         selectedRange={selectedRange}
@@ -83,7 +75,7 @@ export default function HistoryBoard({
           </p>
         </div>
       ) : (
-        <div className="flex min-h-80 flex-1 items-center justify-center">
+        <div className="flex flex-1 items-center justify-center py-50">
           <div className="text-center text-sm font-normal text-text-default">
             <p>{emptyTitle}</p>
             <p>{emptyDescription}</p>

--- a/src/app/(service)/myhistory/components/HistoryBoard.tsx
+++ b/src/app/(service)/myhistory/components/HistoryBoard.tsx
@@ -75,7 +75,7 @@ export default function HistoryBoard({
           </p>
         </div>
       ) : (
-        <div className="flex flex-1 items-center justify-center py-50">
+        <div className="flex min-h-80 flex-1 items-center justify-center">
           <div className="text-center text-sm font-normal text-text-default">
             <p>{emptyTitle}</p>
             <p>{emptyDescription}</p>

--- a/src/app/(service)/myhistory/components/HistoryFilterTabs.tsx
+++ b/src/app/(service)/myhistory/components/HistoryFilterTabs.tsx
@@ -2,7 +2,6 @@
  * 히스토리 필터 탭 목록을 렌더링하는 컴포넌트입니다.
  */
 
-import useDragScroll from '@/app/(service)/myhistory/hooks/useDragScroll';
 import type { HistoryFilterTabsProps } from '@/app/(service)/myhistory/types';
 import { cn } from '@/utils/cn';
 
@@ -11,25 +10,8 @@ export default function HistoryFilterTabs({
   filters,
   onSelectFilter,
 }: HistoryFilterTabsProps) {
-  const {
-    containerRef,
-    handleClickCapture,
-    handlePointerCancel,
-    handlePointerDown,
-    handlePointerMove,
-    handlePointerUp,
-  } = useDragScroll();
-
   return (
-    <ul
-      ref={containerRef}
-      className="flex cursor-grab gap-1 overflow-x-auto select-none md:gap-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden active:cursor-grabbing"
-      onClickCapture={handleClickCapture}
-      onPointerCancel={handlePointerCancel}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-    >
+    <ul className="flex gap-1 overflow-x-auto overscroll-x-contain md:gap-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
       {filters.map((filter) => {
         const isActive = activeFilterId === filter.id;
 
@@ -40,7 +22,7 @@ export default function HistoryFilterTabs({
               data-allow-unsaved="true"
               onClick={() => onSelectFilter(filter.id)}
               className={cn(
-                'flex h-8.25 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-full border px-3 text-sm font-medium md:h-10.75 md:px-4 md:text-base',
+                'flex h-8.25 shrink-0 touch-manipulation items-center justify-center gap-1.5 whitespace-nowrap rounded-full border px-3 text-sm font-medium md:h-10.75 md:px-4 md:text-base',
                 isActive
                   ? 'border-brand-primary bg-brand-primary text-text-inverse'
                   : 'border-background-tertiary bg-background-inverse text-text-primary',

--- a/src/app/(service)/myhistory/components/HistoryFilterTabs.tsx
+++ b/src/app/(service)/myhistory/components/HistoryFilterTabs.tsx
@@ -2,6 +2,7 @@
  * 히스토리 필터 탭 목록을 렌더링하는 컴포넌트입니다.
  */
 
+import useDragScroll from '@/app/(service)/myhistory/hooks/useDragScroll';
 import type { HistoryFilterTabsProps } from '@/app/(service)/myhistory/types';
 import { cn } from '@/utils/cn';
 
@@ -10,8 +11,21 @@ export default function HistoryFilterTabs({
   filters,
   onSelectFilter,
 }: HistoryFilterTabsProps) {
+  const {
+    containerRef,
+    handleClickCapture,
+    handlePointerDown,
+    handlePointerMove,
+  } = useDragScroll();
+
   return (
-    <ul className="flex gap-1 overflow-x-auto overscroll-x-contain md:gap-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+    <ul
+      ref={containerRef}
+      onClickCapture={handleClickCapture}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      className="flex cursor-grab gap-1 overflow-x-auto overscroll-x-contain select-none md:gap-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden active:cursor-grabbing"
+    >
       {filters.map((filter) => {
         const isActive = activeFilterId === filter.id;
 

--- a/src/app/(service)/myhistory/components/MyHistorySummary.tsx
+++ b/src/app/(service)/myhistory/components/MyHistorySummary.tsx
@@ -57,17 +57,23 @@ export default function MyHistorySummary({
                 >
                   <div className="overflow-hidden">
                     <ul className="w-67.5 rounded-xl border border-background-tertiary bg-background-inverse py-3">
-                      {item.details.map((detail) => (
-                        <li
-                          key={detail.id}
-                          className="flex items-center justify-between px-5 py-1.5 text-sm font-medium text-text-primary"
-                        >
-                          <span>{detail.title}</span>
-                          <span className="text-brand-primary">
-                            {detail.countText}
-                          </span>
+                      {item.details.length === 0 ? (
+                        <li className="px-5 py-1.5 text-sm font-medium text-text-secondary">
+                          할일이 없습니다.
                         </li>
-                      ))}
+                      ) : (
+                        item.details.map((detail) => (
+                          <li
+                            key={detail.id}
+                            className="flex items-center justify-between px-5 py-1.5 text-sm font-medium text-text-primary"
+                          >
+                            <span>{detail.title}</span>
+                            <span className="text-brand-primary">
+                              {detail.countText}
+                            </span>
+                          </li>
+                        ))
+                      )}
                     </ul>
                   </div>
                 </div>

--- a/src/app/(service)/myhistory/constants.ts
+++ b/src/app/(service)/myhistory/constants.ts
@@ -59,7 +59,7 @@ export const HISTORY_TASK_CARD_TEXT = {
   delete: '삭제하기',
   deleteError: '할 일 삭제에 실패했습니다.',
   deleteSuccess: '삭제되었습니다.',
-  edit: '수정하기',
+  edit: '상세보기',
 } as const;
 
 export const MY_HISTORY_API_TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID ?? '';

--- a/src/app/(service)/myhistory/hooks/useDragScroll.ts
+++ b/src/app/(service)/myhistory/hooks/useDragScroll.ts
@@ -1,8 +1,9 @@
 /**
- * 가로 스크롤 영역을 포인터 드래그로 이동할 수 있게 하는 훅입니다.
+ * 가로 스크롤 영역을 마우스로 드래그할 수 있게 하는 훅입니다.
+ * 터치 환경에서는 브라우저 기본 가로 스크롤을 그대로 사용합니다.
  */
 
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { HISTORY_FILTER_TABS_DRAG_THRESHOLD } from '@/app/(service)/myhistory/constants';
 import type { UseDragScrollReturn } from '@/app/(service)/myhistory/types';
@@ -14,32 +15,6 @@ export default function useDragScroll(): UseDragScrollReturn {
   const hasDraggedRef = useRef(false);
   const startXRef = useRef(0);
   const startScrollLeftRef = useRef(0);
-  const activePointerIdRef = useRef<number | null>(null);
-
-  const releasePointerCapture = (target: HTMLElement) => {
-    const pointerId = activePointerIdRef.current;
-
-    if (pointerId === null || !target.hasPointerCapture(pointerId)) {
-      activePointerIdRef.current = null;
-      return;
-    }
-
-    target.releasePointerCapture(pointerId);
-    activePointerIdRef.current = null;
-  };
-
-  const resetDragState = () => {
-    isPointerDownRef.current = false;
-
-    if (!isDraggingRef.current) {
-      return;
-    }
-
-    isDraggingRef.current = false;
-    window.requestAnimationFrame(() => {
-      hasDraggedRef.current = false;
-    });
-  };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLElement>) => {
     if (event.pointerType !== 'mouse' || event.button !== 0) {
@@ -55,8 +30,6 @@ export default function useDragScroll(): UseDragScrollReturn {
     hasDraggedRef.current = false;
     startXRef.current = event.clientX;
     startScrollLeftRef.current = containerRef.current.scrollLeft;
-    activePointerIdRef.current = event.pointerId;
-    event.currentTarget.setPointerCapture(event.pointerId);
   };
 
   const handlePointerMove = (event: React.PointerEvent<HTMLElement>) => {
@@ -76,17 +49,28 @@ export default function useDragScroll(): UseDragScrollReturn {
     event.preventDefault();
   };
 
-  const handlePointerUp = (event: React.PointerEvent<HTMLElement>) => {
-    releasePointerCapture(event.currentTarget);
-    resetDragState();
-  };
+  useEffect(() => {
+    const handlePointerEnd = () => {
+      isPointerDownRef.current = false;
 
-  const handlePointerCancel = (event: React.PointerEvent<HTMLElement>) => {
-    releasePointerCapture(event.currentTarget);
-    isPointerDownRef.current = false;
-    isDraggingRef.current = false;
-    hasDraggedRef.current = false;
-  };
+      if (!isDraggingRef.current) {
+        return;
+      }
+
+      isDraggingRef.current = false;
+      window.requestAnimationFrame(() => {
+        hasDraggedRef.current = false;
+      });
+    };
+
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+
+    return () => {
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    };
+  }, []);
 
   const handleClickCapture = (event: React.MouseEvent<HTMLElement>) => {
     if (!hasDraggedRef.current) {
@@ -102,9 +86,7 @@ export default function useDragScroll(): UseDragScrollReturn {
   return {
     containerRef,
     handleClickCapture,
-    handlePointerCancel,
     handlePointerDown,
     handlePointerMove,
-    handlePointerUp,
   };
 }

--- a/src/app/(service)/myhistory/hooks/useHistoryTaskCardMutation.tsx
+++ b/src/app/(service)/myhistory/hooks/useHistoryTaskCardMutation.tsx
@@ -30,6 +30,13 @@ export default function useHistoryTaskCardMutation({
     typeof meData.nickname === 'string'
       ? meData.nickname
       : '';
+  const assigneeImage =
+    typeof meData === 'object' &&
+    meData !== null &&
+    'image' in meData &&
+    typeof meData.image === 'string'
+      ? meData.image
+      : null;
 
   const handleOpenDetailPanel = () => {
     openRightPanel({
@@ -37,6 +44,7 @@ export default function useHistoryTaskCardMutation({
         <TaskDetailPanelContent
           key={task.id}
           apiTeamId={MY_HISTORY_API_TEAM_ID}
+          assigneeImage={assigneeImage}
           assigneeName={assigneeName}
           completionActionDoneValue={!task.isCompleted}
           completionActionLabel={

--- a/src/app/(service)/myhistory/types.ts
+++ b/src/app/(service)/myhistory/types.ts
@@ -209,10 +209,8 @@ export type UseHistoryTaskListSourcesQueryParams = {
 export type UseDragScrollReturn = {
   containerRef: RefObject<HTMLUListElement | null>;
   handleClickCapture: (event: ReactMouseEvent<HTMLElement>) => void;
-  handlePointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
   handlePointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
   handlePointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
-  handlePointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
 };
 
 export type HistoryMonthNavigatorProps = {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -7,23 +7,62 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import { ToastProvider } from '@/components/common/toast';
-import { clearAuthSession, hasAuthSession } from '@/utils/authSession';
+import {
+  clearAuthSession,
+  hasAuthSession,
+  subscribeAuthSessionChange,
+} from '@/utils/authSession';
 import { queryClient } from '@/utils/queryClient';
 
 function MidnightSignOut() {
   useEffect(() => {
-    if (!hasAuthSession()) return;
+    let timerId: number | null = null;
 
-    const now = new Date();
-    const midnight = new Date();
-    midnight.setHours(24, 0, 0, 0);
-    const msUntilMidnight = midnight.getTime() - now.getTime();
+    const clearTimer = () => {
+      if (timerId === null) {
+        return;
+      }
 
-    const timer = setTimeout(() => {
-      clearAuthSession('expired');
-    }, msUntilMidnight);
+      window.clearTimeout(timerId);
+      timerId = null;
+    };
 
-    return () => clearTimeout(timer);
+    const scheduleMidnightSignOut = () => {
+      clearTimer();
+
+      if (!hasAuthSession()) {
+        return;
+      }
+
+      const now = new Date();
+      const midnight = new Date();
+      midnight.setHours(24, 0, 0, 0);
+      const msUntilMidnight = midnight.getTime() - now.getTime();
+
+      timerId = window.setTimeout(() => {
+        clearAuthSession('expired');
+      }, msUntilMidnight);
+    };
+
+    scheduleMidnightSignOut();
+
+    const unsubscribe = subscribeAuthSessionChange((reason) => {
+      if (
+        reason === 'manual' ||
+        reason === 'expired' ||
+        reason === 'unauthorized'
+      ) {
+        clearTimer();
+        return;
+      }
+
+      scheduleMidnightSignOut();
+    });
+
+    return () => {
+      clearTimer();
+      unsubscribe();
+    };
   }, []);
 
   return null;

--- a/src/components/common/rightPanel/components/RightPanel.tsx
+++ b/src/components/common/rightPanel/components/RightPanel.tsx
@@ -34,22 +34,15 @@ export default function RightPanel({
 
   return (
     <>
-      <div
+      <aside
+        aria-label={ariaLabel}
         className={cn(
-          'hidden relative z-20 w-0 shrink-0 transition-[width] duration-300 ease-out 2xl:block',
-          isVisible ? 'w-195 overflow-visible' : 'w-0 overflow-hidden',
+          'hidden fixed right-0 top-0 z-50 h-dvh w-195 border-l border-background-tertiary bg-background-inverse shadow-[-16px_0_32px_rgba(15,23,42,0.08)] transition-transform duration-300 ease-out will-change-transform transform-gpu 2xl:block',
+          isVisible ? 'translate-x-0' : 'translate-x-full pointer-events-none',
         )}
       >
-        <aside
-          aria-label={ariaLabel}
-          className={cn(
-            'sticky top-0 z-20 h-dvh w-195 border-l border-background-tertiary bg-background-inverse shadow-[-16px_0_32px_rgba(15,23,42,0.08)] transition-[transform,opacity] duration-300 ease-out will-change-transform transform-gpu',
-            isVisible ? 'translate-x-0 opacity-100' : 'translate-x-8 opacity-0',
-          )}
-        >
-          {shell}
-        </aside>
-      </div>
+        {shell}
+      </aside>
 
       <aside
         aria-label={ariaLabel}

--- a/src/components/common/rightPanel/components/RightPanel.tsx
+++ b/src/components/common/rightPanel/components/RightPanel.tsx
@@ -36,14 +36,14 @@ export default function RightPanel({
     <>
       <div
         className={cn(
-          'hidden w-0 shrink-0 transition-[width] duration-300 ease-out 2xl:block',
+          'hidden relative z-20 w-0 shrink-0 transition-[width] duration-300 ease-out 2xl:block',
           isVisible ? 'w-195 overflow-visible' : 'w-0 overflow-hidden',
         )}
       >
         <aside
           aria-label={ariaLabel}
           className={cn(
-            'sticky top-0 h-dvh w-195 border-l border-background-tertiary bg-background-inverse shadow-[-16px_0_32px_rgba(15,23,42,0.08)] transition-[transform,opacity] duration-300 ease-out will-change-transform transform-gpu',
+            'sticky top-0 z-20 h-dvh w-195 border-l border-background-tertiary bg-background-inverse shadow-[-16px_0_32px_rgba(15,23,42,0.08)] transition-[transform,opacity] duration-300 ease-out will-change-transform transform-gpu',
             isVisible ? 'translate-x-0 opacity-100' : 'translate-x-8 opacity-0',
           )}
         >

--- a/src/components/layout/components/ServiceLayoutClient.tsx
+++ b/src/components/layout/components/ServiceLayoutClient.tsx
@@ -23,7 +23,7 @@ export default function ServiceLayoutClient({
         <Header />
         <div className="flex min-h-0 flex-1 overflow-x-clip bg-background-secondary">
           <Sidebar />
-          <main className="min-w-0 flex-1 md:pt-0">{children}</main>
+          <main className="min-w-0 flex-1 pt-13 md:pt-0">{children}</main>
           <ServiceRightPanelHost />
         </div>
       </div>

--- a/src/components/layout/header/components/Header.tsx
+++ b/src/components/layout/header/components/Header.tsx
@@ -16,7 +16,6 @@ import ProfileMenuDropdown from '@/components/layout/components/ProfileMenuDropd
 import MobileSidebarDrawer from '@/components/layout/header/components/MobileSidebarDrawer';
 import useMobileSidebar from '@/components/layout/header/hooks/useMobileSidebar';
 import useLayoutAuthState from '@/components/layout/hooks/useLayoutAuthState';
-import useRightPanel from '@/components/layout/hooks/useRightPanel';
 import { ROUTES } from '@/constants/ROUTES';
 
 function subscribeMounted(callback: () => void) {
@@ -124,7 +123,6 @@ function MobileHeaderBar({
 export default function Header() {
   const pathname = usePathname();
   const layoutAuthState = useLayoutAuthState(pathname);
-  const { isRightPanelVisible } = useRightPanel();
 
   const { handleClose, handleToggle, isRendered, isVisible, menuButtonRef } =
     useMobileSidebar();
@@ -145,7 +143,7 @@ export default function Header() {
 
   return (
     <>
-      <div className="md:hidden sticky top-0 z-40">
+      <div className="md:hidden fixed top-0 left-0 right-0 z-41">
         <MobileHeaderBar
           canShowAuthUi={canShowAuthUi}
           currentUserImage={layoutAuthState.currentUser.image}
@@ -156,20 +154,6 @@ export default function Header() {
           pathname={pathname}
         />
       </div>
-
-      {isRightPanelVisible && (
-        <div className="md:hidden fixed inset-x-0 top-0 z-60">
-          <MobileHeaderBar
-            canShowAuthUi={canShowAuthUi}
-            currentUserImage={layoutAuthState.currentUser.image}
-            isVisible={isVisible}
-            logoHref={logoHref}
-            menuButtonRef={menuButtonRef}
-            onToggle={handleToggle}
-            pathname={pathname}
-          />
-        </div>
-      )}
 
       <MobileSidebarDrawer
         isRendered={isRendered}

--- a/src/components/layout/header/components/MobileSidebarDrawer.tsx
+++ b/src/components/layout/header/components/MobileSidebarDrawer.tsx
@@ -26,8 +26,8 @@ export default function MobileSidebarDrawer({
     <>
       <div
         className={cn(
-          'md:hidden fixed inset-0 z-50 bg-text-primary/45 transition-opacity duration-300',
-          isVisible ? 'opacity-100' : 'opacity-0',
+          'md:hidden fixed inset-0 z-41 bg-text-primary/45 transition-opacity duration-300',
+          isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none',
         )}
         onClick={onClose}
         aria-hidden="true"
@@ -38,7 +38,7 @@ export default function MobileSidebarDrawer({
         aria-modal="true"
         aria-label="모바일 사이드바 메뉴"
         className={cn(
-          'md:hidden fixed inset-y-0 left-0 z-50 flex h-dvh w-56 flex-col bg-background-inverse text-text-default shadow-2xl transition-transform duration-300 will-change-transform',
+          'md:hidden fixed inset-y-0 left-0 z-42 flex h-dvh w-56 flex-col bg-background-inverse text-text-default shadow-2xl transition-transform duration-300 will-change-transform',
           isVisible ? 'translate-x-0' : '-translate-x-full',
         )}
       >

--- a/src/components/layout/hooks/useAuthSessionGuard.ts
+++ b/src/components/layout/hooks/useAuthSessionGuard.ts
@@ -4,7 +4,7 @@
 
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -21,10 +21,13 @@ import {
   subscribeAuthSessionChange,
 } from '@/utils/authSession';
 
+const REFRESH_BUFFER_MS = 60 * 1000;
+
 export default function useAuthSessionGuard() {
   const pathname = usePathname();
   const router = useRouter();
   const { showToast } = useToast();
+  const [sessionVersion, setSessionVersion] = useState(0);
 
   useEffect(() => {
     if (isPublicServicePath(pathname)) {
@@ -60,19 +63,7 @@ export default function useAuthSessionGuard() {
       return;
     }
 
-    const remainingTime = expirationTime - Date.now();
-
-    if (remainingTime <= 0) {
-      clearAuthSession('expired');
-      router.replace(
-        buildLoginPath({
-          redirectTo,
-        }),
-      );
-      return;
-    }
-
-    const timeoutId = window.setTimeout(async () => {
+    const handleRefreshOrSignOut = async () => {
       const refreshToken = getStoredRefreshToken();
 
       if (refreshToken) {
@@ -91,7 +82,7 @@ export default function useAuthSessionGuard() {
 
             if (data.accessToken) {
               setStoredAccessToken(data.accessToken);
-              return;
+              return true;
             }
           }
         } catch (error) {
@@ -106,15 +97,32 @@ export default function useAuthSessionGuard() {
           redirectTo,
         }),
       );
+      return false;
+    };
+
+    const remainingTime = expirationTime - Date.now() - REFRESH_BUFFER_MS;
+
+    if (remainingTime <= 0) {
+      void handleRefreshOrSignOut();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void handleRefreshOrSignOut();
     }, remainingTime);
 
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [pathname, router, showToast]);
+  }, [pathname, router, sessionVersion, showToast]);
 
   useEffect(() => {
-    const unsubscribe = subscribeAuthSessionChange(() => {
+    const unsubscribe = subscribeAuthSessionChange((reason) => {
+      if (reason === 'saved' || reason === 'refreshed') {
+        setSessionVersion((previousVersion) => previousVersion + 1);
+        return;
+      }
+
       router.refresh();
     });
 

--- a/src/components/layout/hooks/useLayoutMediaSync.ts
+++ b/src/components/layout/hooks/useLayoutMediaSync.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+/**
+ * 뷰포트 크기에 따라 사이드바 기본 펼침 상태를 동기화하는 훅입니다.
+ */
+
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 
 import { SIDEBAR_DESKTOP_MEDIA_QUERY } from '@/components/layout/sidebar/constants';
@@ -25,7 +29,7 @@ export default function useLayoutMediaSync({
     desktopSidebarExpandedRef.current = isSidebarExpanded;
   }, [isSidebarExpanded]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const sidebarMediaQuery = window.matchMedia(SIDEBAR_DESKTOP_MEDIA_QUERY);
 
     const syncInitialSidebarState = () => {

--- a/src/components/layout/hooks/useServiceLayoutState.ts
+++ b/src/components/layout/hooks/useServiceLayoutState.ts
@@ -17,15 +17,13 @@ import useLockBodyScroll from '@/components/layout/hooks/useLockBodyScroll';
 import type { ServiceLayoutContextValue } from '@/components/layout/types';
 
 const OVERLAY_ANIMATION_DURATION = 300;
-const RIGHT_PANEL_INLINE_DESKTOP_MEDIA_QUERY = '(min-width: 1536px)';
+const SIDEBAR_VISIBLE_MEDIA_QUERY = '(min-width: 768px)';
 
 export default function useServiceLayoutState(): ServiceLayoutContextValue {
   const pathname = usePathname();
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
-  const [
-    isInlineDesktopRightPanelViewport,
-    setIsInlineDesktopRightPanelViewport,
-  ] = useState(false);
+  const [isSidebarVisibleViewport, setIsSidebarVisibleViewport] =
+    useState(false);
   const [rightPanelContent, setRightPanelContent] =
     useState<RightPanelContent | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -47,12 +45,10 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
   });
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia(
-      RIGHT_PANEL_INLINE_DESKTOP_MEDIA_QUERY,
-    );
+    const mediaQuery = window.matchMedia(SIDEBAR_VISIBLE_MEDIA_QUERY);
 
     const updateViewportState = () => {
-      setIsInlineDesktopRightPanelViewport(mediaQuery.matches);
+      setIsSidebarVisibleViewport(mediaQuery.matches);
     };
 
     updateViewportState();
@@ -135,7 +131,7 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
     (content: RightPanelContent) => {
       setRightPanelContent(content);
 
-      if (!isInlineDesktopRightPanelViewport) {
+      if (!isSidebarVisibleViewport) {
         setIsSidebarExpanded(false);
       }
 
@@ -151,9 +147,9 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
     },
     [
       closeMobileSidebar,
-      isInlineDesktopRightPanelViewport,
       isMobileSidebarVisible,
       isRightPanelVisible,
+      isSidebarVisibleViewport,
       openRightPanelAnimated,
     ],
   );
@@ -174,7 +170,7 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
   useLockBodyScroll({
     isScrollLocked:
       isMobileSidebarRendered ||
-      (isRightPanelVisible && !isInlineDesktopRightPanelViewport),
+      (isRightPanelVisible && !isSidebarVisibleViewport),
   });
 
   return {

--- a/src/components/layout/hooks/useServiceLayoutState.ts
+++ b/src/components/layout/hooks/useServiceLayoutState.ts
@@ -4,7 +4,7 @@
 
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { usePathname } from 'next/navigation';
 
@@ -17,9 +17,15 @@ import useLockBodyScroll from '@/components/layout/hooks/useLockBodyScroll';
 import type { ServiceLayoutContextValue } from '@/components/layout/types';
 
 const OVERLAY_ANIMATION_DURATION = 300;
+const RIGHT_PANEL_INLINE_DESKTOP_MEDIA_QUERY = '(min-width: 1536px)';
+
 export default function useServiceLayoutState(): ServiceLayoutContextValue {
   const pathname = usePathname();
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
+  const [
+    isInlineDesktopRightPanelViewport,
+    setIsInlineDesktopRightPanelViewport,
+  ] = useState(false);
   const [rightPanelContent, setRightPanelContent] =
     useState<RightPanelContent | null>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
@@ -39,6 +45,23 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
   } = useAnimatedVisibility({
     duration: OVERLAY_ANIMATION_DURATION,
   });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(
+      RIGHT_PANEL_INLINE_DESKTOP_MEDIA_QUERY,
+    );
+
+    const updateViewportState = () => {
+      setIsInlineDesktopRightPanelViewport(mediaQuery.matches);
+    };
+
+    updateViewportState();
+    mediaQuery.addEventListener('change', updateViewportState);
+
+    return () => {
+      mediaQuery.removeEventListener('change', updateViewportState);
+    };
+  }, []);
 
   const closeRightPanel = useCallback(() => {
     const unsavedGuard = getRightPanelUnsavedGuard();
@@ -111,7 +134,10 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
   const openRightPanel = useCallback(
     (content: RightPanelContent) => {
       setRightPanelContent(content);
-      setIsSidebarExpanded(false);
+
+      if (!isInlineDesktopRightPanelViewport) {
+        setIsSidebarExpanded(false);
+      }
 
       if (isMobileSidebarVisible) {
         closeMobileSidebar();
@@ -125,6 +151,7 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
     },
     [
       closeMobileSidebar,
+      isInlineDesktopRightPanelViewport,
       isMobileSidebarVisible,
       isRightPanelVisible,
       openRightPanelAnimated,
@@ -145,7 +172,9 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
   });
 
   useLockBodyScroll({
-    isScrollLocked: isMobileSidebarRendered || isRightPanelVisible,
+    isScrollLocked:
+      isMobileSidebarRendered ||
+      (isRightPanelVisible && !isInlineDesktopRightPanelViewport),
   });
 
   return {

--- a/src/components/layout/hooks/useServiceLayoutState.ts
+++ b/src/components/layout/hooks/useServiceLayoutState.ts
@@ -131,27 +131,13 @@ export default function useServiceLayoutState(): ServiceLayoutContextValue {
     (content: RightPanelContent) => {
       setRightPanelContent(content);
 
-      if (!isSidebarVisibleViewport) {
-        setIsSidebarExpanded(false);
-      }
-
-      if (isMobileSidebarVisible) {
-        closeMobileSidebar();
-      }
-
       if (isRightPanelVisible) {
         return;
       }
 
       openRightPanelAnimated();
     },
-    [
-      closeMobileSidebar,
-      isMobileSidebarVisible,
-      isRightPanelVisible,
-      isSidebarVisibleViewport,
-      openRightPanelAnimated,
-    ],
+    [isRightPanelVisible, openRightPanelAnimated],
   );
 
   useLayoutMediaSync({

--- a/src/components/layout/sidebar/components/SidebarFooter.tsx
+++ b/src/components/layout/sidebar/components/SidebarFooter.tsx
@@ -32,6 +32,10 @@ function getServerSnapshot() {
   return false;
 }
 
+function getDisplayEmail(email: string) {
+  return email.length > 13 ? `${email.slice(0, 13)}...` : email;
+}
+
 export default function SidebarFooter({ isExpanded }: SidebarFooterProps) {
   const { handleSidebarInteraction } = useSidebar();
   const pathname = usePathname();
@@ -82,13 +86,16 @@ export default function SidebarFooter({ isExpanded }: SidebarFooterProps) {
               </span>
 
               {isExpanded ? (
-                <span className="animate-fadeIn flex min-w-0 flex-col [animation-delay:150ms] [animation-fill-mode:both]">
+                <span className="animate-fadeIn flex min-w-0 flex-1 flex-col [animation-delay:150ms] [animation-fill-mode:both]">
                   <span className="truncate text-base font-semibold text-text-primary">
                     {layoutAuthState.currentUser.name}
                   </span>
                   {layoutAuthState.currentUser.email ? (
-                    <span className="truncate text-sm font-medium text-text-default">
-                      {layoutAuthState.currentUser.email}
+                    <span
+                      title={layoutAuthState.currentUser.email}
+                      className="block min-w-0 text-sm font-medium text-text-default"
+                    >
+                      {getDisplayEmail(layoutAuthState.currentUser.email)}
                     </span>
                   ) : null}
                 </span>

--- a/src/components/layout/sidebar/components/SidebarFooter.tsx
+++ b/src/components/layout/sidebar/components/SidebarFooter.tsx
@@ -32,8 +32,8 @@ function getServerSnapshot() {
   return false;
 }
 
-function getDisplayEmail(email: string) {
-  return email.length > 13 ? `${email.slice(0, 13)}...` : email;
+function getDisplayEmail(email: string, maxLength: number) {
+  return email.length > maxLength ? `${email.slice(0, maxLength)}...` : email;
 }
 
 export default function SidebarFooter({ isExpanded }: SidebarFooterProps) {
@@ -95,7 +95,12 @@ export default function SidebarFooter({ isExpanded }: SidebarFooterProps) {
                       title={layoutAuthState.currentUser.email}
                       className="block min-w-0 text-sm font-medium text-text-default"
                     >
-                      {getDisplayEmail(layoutAuthState.currentUser.email)}
+                      <span className="md:hidden">
+                        {getDisplayEmail(layoutAuthState.currentUser.email, 13)}
+                      </span>
+                      <span className="hidden md:inline">
+                        {getDisplayEmail(layoutAuthState.currentUser.email, 20)}
+                      </span>
                     </span>
                   ) : null}
                 </span>

--- a/src/components/layout/sidebar/components/SidebarFooter.tsx
+++ b/src/components/layout/sidebar/components/SidebarFooter.tsx
@@ -86,9 +86,9 @@ export default function SidebarFooter({ isExpanded }: SidebarFooterProps) {
                   <span className="truncate text-base font-semibold text-text-primary">
                     {layoutAuthState.currentUser.name}
                   </span>
-                  {layoutAuthState.profileTeamName ? (
+                  {layoutAuthState.currentUser.email ? (
                     <span className="truncate text-sm font-medium text-text-default">
-                      {layoutAuthState.profileTeamName}
+                      {layoutAuthState.currentUser.email}
                     </span>
                   ) : null}
                 </span>

--- a/src/hooks/taskMutationCache.ts
+++ b/src/hooks/taskMutationCache.ts
@@ -1,5 +1,5 @@
 /**
- * 할 일 완료 상태 변경 시 필요한 캐시 반영과 후속 재검증을 모아둔 유틸입니다.
+ * 할 일 완료 상태 변경과 삭제 시 필요한 캐시 반영과 후속 재검증을 모아둔 유틸입니다.
  */
 
 'use client';
@@ -7,6 +7,8 @@
 import type { QueryKeyId } from '@/api/queryKeys';
 import { queryKeys } from '@/api/queryKeys';
 import {
+  removeTaskFromGroupDetail,
+  removeTaskFromTaskListDetail,
   syncCheckedTaskToGroupDetail,
   syncCheckedTaskToTaskListDetail,
 } from '@/app/(service)/[teamid]/tasklist/utils/taskListQueryCache';
@@ -80,4 +82,101 @@ export async function invalidateTaskCheckedFollowups({
       queryKey: queryKeys.user.completedTaskSummary(),
     }),
   ]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function removeTaskFromCompletedTasksData(
+  completedTasksData: unknown,
+  taskId: string,
+) {
+  if (!isRecord(completedTasksData)) {
+    return completedTasksData;
+  }
+
+  if (isRecord(completedTasksData.data)) {
+    const data = completedTasksData.data;
+    const tasksDone = Array.isArray(data.tasksDone) ? data.tasksDone : null;
+
+    if (!tasksDone) {
+      return completedTasksData;
+    }
+
+    return {
+      ...completedTasksData,
+      data: {
+        ...data,
+        tasksDone: tasksDone.filter(
+          (task) =>
+            !isRecord(task) ||
+            (typeof task.id !== 'number' && typeof task.id !== 'string') ||
+            String(task.id) !== taskId,
+        ),
+      },
+    };
+  }
+
+  const tasksDone = Array.isArray(completedTasksData.tasksDone)
+    ? completedTasksData.tasksDone
+    : null;
+
+  if (!tasksDone) {
+    return completedTasksData;
+  }
+
+  return {
+    ...completedTasksData,
+    tasksDone: tasksDone.filter(
+      (task) =>
+        !isRecord(task) ||
+        (typeof task.id !== 'number' && typeof task.id !== 'string') ||
+        String(task.id) !== taskId,
+    ),
+  };
+}
+
+type SyncDeletedTaskCachesParams = {
+  queryClient: QueryClient;
+  taskId: QueryKeyId;
+  taskListId: QueryKeyId;
+  teamId: string;
+};
+
+export function syncDeletedTaskCaches({
+  queryClient,
+  taskId,
+  taskListId,
+  teamId,
+}: SyncDeletedTaskCachesParams) {
+  const taskIdString = String(taskId);
+  const taskListIdString = String(taskListId);
+
+  queryClient.setQueryData<GroupDetail | undefined>(
+    queryKeys.team.detail(teamId),
+    (previousGroupDetail) =>
+      removeTaskFromGroupDetail(
+        previousGroupDetail,
+        taskListIdString,
+        taskIdString,
+      ),
+  );
+  queryClient.setQueriesData<TaskListDetail | undefined>(
+    {
+      queryKey: queryKeys.taskList.detail(teamId, taskListIdString),
+    },
+    (previousTaskListDetail) =>
+      removeTaskFromTaskListDetail(previousTaskListDetail, taskIdString),
+  );
+  queryClient.setQueriesData(
+    {
+      queryKey: queryKeys.user.completedTasks(),
+    },
+    (previousCompletedTasksData) =>
+      removeTaskFromCompletedTasksData(
+        previousCompletedTasksData,
+        taskIdString,
+      ),
+  );
 }

--- a/src/hooks/useTaskMutations.ts
+++ b/src/hooks/useTaskMutations.ts
@@ -16,8 +16,11 @@ import { deleteTask, updateTask } from '@/api/taskApi';
 import type { TaskUpdateBody } from '@/api/types';
 import {
   invalidateTaskCheckedFollowups,
+  syncDeletedTaskCaches,
   syncTaskCheckedCaches,
 } from '@/hooks/taskMutationCache';
+import type { GroupDetail } from '@/types/group';
+import type { TaskListDetail } from '@/types/task';
 
 type UpdateTaskData = Awaited<ReturnType<typeof updateTask>>;
 type DeleteTaskData = Awaited<ReturnType<typeof deleteTask>>;
@@ -104,6 +107,8 @@ export function useDeleteTaskMutation(
   options?: MutationOptionsOverrides<DeleteTaskData, DeleteTaskVariables>,
 ) {
   const queryClient = useQueryClient();
+  const handleError = options?.onError;
+  const handleMutate = options?.onMutate;
   const handleSuccess = options?.onSuccess;
 
   return useMutation(
@@ -116,14 +121,96 @@ export function useDeleteTaskMutation(
       }: DeleteTaskVariables) => deleteTask(teamId, taskListId, taskId, token),
       options: {
         ...options,
+        onMutate: async (variables, context) => {
+          const taskListIdString = String(variables.taskListId);
+
+          await Promise.all([
+            queryClient.cancelQueries({
+              queryKey: queryKeys.team.detail(variables.teamId),
+            }),
+            queryClient.cancelQueries({
+              queryKey: queryKeys.taskList.detail(
+                variables.teamId,
+                taskListIdString,
+              ),
+            }),
+            queryClient.cancelQueries({
+              queryKey: queryKeys.user.completedTasks(),
+            }),
+          ]);
+
+          const previousTeamDetail = queryClient.getQueryData<GroupDetail>(
+            queryKeys.team.detail(variables.teamId),
+          );
+          const previousTaskListDetails = queryClient.getQueriesData<
+            TaskListDetail | undefined
+          >({
+            queryKey: queryKeys.taskList.detail(
+              variables.teamId,
+              taskListIdString,
+            ),
+          });
+          const previousCompletedTasksQueries = queryClient.getQueriesData({
+            queryKey: queryKeys.user.completedTasks(),
+          });
+
+          syncDeletedTaskCaches({
+            queryClient,
+            taskId: variables.taskId,
+            taskListId: variables.taskListId,
+            teamId: variables.teamId,
+          });
+
+          const externalOnMutateResult = await handleMutate?.(
+            variables,
+            context,
+          );
+
+          return {
+            externalOnMutateResult,
+            previousCompletedTasksQueries,
+            previousTaskListDetails,
+            previousTeamDetail,
+          };
+        },
+        onError: async (error, variables, onMutateResult, context) => {
+          if (onMutateResult?.previousTeamDetail !== undefined) {
+            queryClient.setQueryData(
+              queryKeys.team.detail(variables.teamId),
+              onMutateResult.previousTeamDetail,
+            );
+          }
+
+          onMutateResult?.previousTaskListDetails?.forEach(
+            ([queryKey, previousTaskListDetail]) => {
+              queryClient.setQueryData(queryKey, previousTaskListDetail);
+            },
+          );
+
+          onMutateResult?.previousCompletedTasksQueries?.forEach(
+            ([queryKey, previousCompletedTasks]) => {
+              queryClient.setQueryData(queryKey, previousCompletedTasks);
+            },
+          );
+
+          await handleError?.(
+            error,
+            variables,
+            onMutateResult?.externalOnMutateResult,
+            context,
+          );
+        },
         onSuccess: async (data, variables, onMutateResult, context) => {
           await Promise.all([
-            queryClient.invalidateQueries({
+            queryClient.removeQueries({
               queryKey: queryKeys.task.detail(
                 variables.teamId,
                 variables.taskId,
                 variables.taskListId,
               ),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.team.detail(variables.teamId),
             }),
             queryClient.invalidateQueries({
               queryKey: queryKeys.taskList.detail(
@@ -138,7 +225,12 @@ export function useDeleteTaskMutation(
               queryKey: queryKeys.user.completedTaskSummary(),
             }),
           ]);
-          await handleSuccess?.(data, variables, onMutateResult, context);
+          await handleSuccess?.(
+            data,
+            variables,
+            onMutateResult?.externalOnMutateResult,
+            context,
+          );
         },
       },
     }),

--- a/src/utils/authSession/index.ts
+++ b/src/utils/authSession/index.ts
@@ -38,6 +38,22 @@ function emitAuthSessionChange(reason: AuthSessionChangeReason) {
   );
 }
 
+function persistAuthSession(
+  session: AuthSession,
+  reason: AuthSessionChangeReason,
+) {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.setItem(
+    AUTH_SESSION_STORAGE_KEY,
+    JSON.stringify(session),
+  );
+  document.cookie = buildAccessTokenCookie(session.accessToken);
+  emitAuthSessionChange(reason);
+}
+
 export function getAuthSession() {
   if (!isBrowser()) {
     return null;
@@ -57,16 +73,7 @@ export function getAuthSession() {
 }
 
 export function saveAuthSession(session: AuthSession) {
-  if (!isBrowser()) {
-    return;
-  }
-
-  window.localStorage.setItem(
-    AUTH_SESSION_STORAGE_KEY,
-    JSON.stringify(session),
-  );
-  document.cookie = buildAccessTokenCookie(session.accessToken);
-  emitAuthSessionChange('saved');
+  persistAuthSession(session, 'saved');
 }
 
 export function clearAuthSession(reason: AuthSessionChangeReason = 'manual') {
@@ -106,7 +113,7 @@ export function setStoredAccessToken(accessToken: string) {
   const session = getAuthSession();
   if (!session) return;
 
-  saveAuthSession({ ...session, accessToken });
+  persistAuthSession({ ...session, accessToken }, 'refreshed');
 }
 
 export function hasAuthSession() {

--- a/src/utils/authSession/types.ts
+++ b/src/utils/authSession/types.ts
@@ -1,5 +1,6 @@
 export type AuthSessionChangeReason =
   | 'saved'
+  | 'refreshed'
   | 'manual'
   | 'expired'
   | 'unauthorized';


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #179 

## 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [ ] 콘솔 로그/에러 없음
- [ ] 기능 정상 동작
- [ ] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 내 히스토리 페이지에서 팀 안눌리는 버그
- 할일 삭제하고 refetch가 안되고 있음 / 응답을 기다리기 전에 미리 삭제되게 먼저 낙관적 업데이트
- 상세할일에 프로필이(아이디 옆) 안나옴
- 할일이 0개인 할일목록 눌렀을 때, 빈칸만 나오는 상태 -> 할일이 없습니다 문구 추가
- 내 히스토리 오른쪽 패널 깨짐
- 해야할 작업이 없을 때 여백이 너무 높아 스크롤 -> 여백 줄이기
- 상세보기로 이름 바꾸기
- 리스트페이지 오른쪽 패널 위로 덮이게 수정
- 프로필 아래 팀 말고 이메일 나오게 수정

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
